### PR TITLE
Reenable ssl and fix lgtm build

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -10,6 +10,8 @@ extraction:
         - g++-10
         - ccache
       script:
+        - mkdir ~/.conan
+        - cat /usr/local/share/ca-certificates/semmle-cache-ca/semmle-cache-ca.crt >> ~/.conan/cacert.pem
         - python3 -m pip install --upgrade pip setuptools
         - python3 -m pip install conan
         - python3 -m pip install cmake
@@ -18,8 +20,6 @@ extraction:
     configure:
       command:
         - mkdir build
-        - cd ./build
-        - cmake -D ENABLE_COVERAGE:BOOL=TRUE ../
-    index: # Customizable step used by all languages.
-      build_command:
-        - cmake --build . -- -j2
+        - cmake -D ENABLE_COVERAGE:BOOL=TRUE -S . -B build
+      index:
+        build_command: cmake --build ./build -- -j2

--- a/cmake/Conan.cmake
+++ b/cmake/Conan.cmake
@@ -8,18 +8,12 @@ macro(run_conan)
   include(${CMAKE_BINARY_DIR}/conan.cmake)
 
   conan_add_remote(
-    NAME
-    conan-center
-    URL
-    https://api.bintray.com/conan/conan/conan-center
-    VERIFY_SSL False)
+    NAME conan-center
+    URL https://api.bintray.com/conan/conan/conan-center)
 
   conan_add_remote(
-    NAME
-    bincrafters
-    URL
-    https://api.bintray.com/conan/bincrafters/public-conan
-    VERIFY_SSL False)
+    NAME bincrafters
+    URL https://api.bintray.com/conan/bincrafters/public-conan)
 
   conan_cmake_run(
     REQUIRES


### PR DESCRIPTION
- Reenable ssl verification for conan reposiories (was disabled for debugging lgtm analysis)
- Fix lgtm build
  - explicitly add the certificate for lgtm's caching https proxy to conan's certificate store
  - fix the build directory for the make command

successful lgtm test build:
https://lgtm.com/logs/fb67d447c496f6f37861b1c2ffa624532198b1c9/lang:cpp