### PR TITLE
Simple hello world using refl-cpp

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,7 @@ include(cmake/StaticAnalyzers.cmake)
 option(BUILD_SHARED_LIBS "Enable compilation of shared libraries" OFF)
 option(ENABLE_TESTING "Enable Test Builds" ON)
 option(ENABLE_FUZZING "Enable Fuzzing Builds" OFF)
+option(ENABLE_CONCEPTS "Enable Concepts Builds" ON)
 
 # Very basic PCH example
 option(ENABLE_PCH "Enable Precompiled Headers" OFF)
@@ -72,6 +73,11 @@ endif()
 if(ENABLE_FUZZING)
   message("Building Fuzz Tests, using fuzzing sanitizer https://www.llvm.org/docs/LibFuzzer.html")
   add_subdirectory(fuzz_test)
+endif()
+
+if(ENABLE_CONCEPTS)
+  message("Building Concepts")
+  add_subdirectory(concepts)
 endif()
 
 add_subdirectory(src)

--- a/cmake/CompilerWarnings.cmake
+++ b/cmake/CompilerWarnings.cmake
@@ -47,6 +47,7 @@ function(set_project_warnings project_name)
       -Wnull-dereference # warn if a null dereference is detected
       -Wdouble-promotion # warn if float is implicit promoted to double
       -Wformat=2 # warn on security issues around functions that format output (ie printf)
+      -Wno-gnu-zero-variadic-macro-arguments # allow zero variadic macro arguments (for refl_cpp)
   )
 
   if(WARNINGS_AS_ERRORS)

--- a/cmake/ReflCpp.cmake
+++ b/cmake/ReflCpp.cmake
@@ -1,0 +1,7 @@
+include(FetchContent)
+FetchContent_Declare(
+        refl-cpp
+        GIT_REPOSITORY https://github.com/veselink1/refl-cpp.git
+        GIT_TAG        f192b08e06f934dc5826b7650c14dd88b1baaccf
+)
+FetchContent_MakeAvailable(refl-cpp)

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,4 @@
 ignore:
   - "*/fuzz_test/**/*"
   - "*/test/**/*"
+  - "*/_deps/**/*"

--- a/concepts/CMakeLists.txt
+++ b/concepts/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(refl_cpp)

--- a/concepts/refl_cpp/CMakeLists.txt
+++ b/concepts/refl_cpp/CMakeLists.txt
@@ -1,0 +1,4 @@
+include(${PROJECT_SOURCE_DIR}/cmake/ReflCpp.cmake)
+add_executable(refl_cpp_test refl_cpp_test.cpp)
+target_link_libraries(refl_cpp_test PRIVATE project_options project_warnings)
+target_include_directories(refl_cpp_test SYSTEM PUBLIC ${refl-cpp_SOURCE_DIR})

--- a/concepts/refl_cpp/refl_cpp_test.cpp
+++ b/concepts/refl_cpp/refl_cpp_test.cpp
@@ -1,0 +1,52 @@
+#include <any>
+#include <cassert>
+#include <iostream>
+#include <refl.hpp>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+struct serializable : refl::attr::usage::field, refl::attr::usage::function {};
+
+template<typename T>
+void serialize(std::ostream &os, T &&value) {
+    os << "\n{\n";
+    bool add_comma = false;
+    for_each(refl::reflect(value).members, [&](auto member) {
+        if constexpr (is_readable(member) && refl::descriptor::has_attribute<serializable>(member)) {
+            if (add_comma)
+                os << ",\n";
+            os << "\"" << get_display_name(member) << "\":";
+            os << "\"" << member(value) << "\"";
+            add_comma = true;
+        }
+    });
+    os << "\n}\n";
+}
+
+struct Test {
+    float f = 0.0;
+    int i = 0;
+    std::string s = "";
+};
+
+void debug_test(std::ostream &os, const Test &context) {
+    os << "(" << context.f << ", " << context.i << ", " << context.s << ")";
+}
+
+REFL_TYPE(Test, debug(debug_test), bases<>)
+REFL_FIELD(f, serializable())
+REFL_FIELD(i, serializable())
+REFL_FIELD(s, serializable())
+REFL_END
+
+int main() {
+    std::cout << "Make JSON: ";
+    serialize(std::cout, Test{ 1, 2, "Three" });
+
+    std::cout << "Use debug print function: \n";
+    std::vector<Test> tests{ { 0, 1, "Hello" }, { 1, 0, "World" } };
+    refl::runtime::debug(std::cout, tests);
+
+    std::cout << std::endl;
+}


### PR DESCRIPTION
This adds a concepts folder for refl-cpp and the cmake integration for fetching refl-cpp.
The folder contains a small example, and the CMakeLists.txt shows how to use the refl-cpp made available through CMake.