### PR TITLE
bump to restyled/restyler-clang-format:12.0.0

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -20,9 +20,7 @@ AlignAfterOpenBracket: DontAlign
 AlignConsecutiveAssignments: false
 AlignConsecutiveDeclarations: false
 AlignEscapedNewlines: DontAlign
-# Requires clang 11 in Restyler
-#AlignOperands: AlignAfterOperator
-AlignOperands: true
+AlignOperands: AlignAfterOperator
 AlignTrailingComments: false
 AllowAllParametersOfDeclarationOnNextLine: true
 AllowShortLambdasOnASingleLine: None
@@ -37,9 +35,7 @@ BinPackArguments: true
 BinPackParameters: true
 BraceWrapping:
   AfterClass: false
-  # Requires clang 11 in Restyler
-  #AfterControlStatement: Never
-  AfterControlStatement: false
+  AfterControlStatement: Never
   AfterEnum: false
   AfterFunction: false
   AfterNamespace: false
@@ -127,9 +123,7 @@ AlignAfterOpenBracket: DontAlign
 AlignConsecutiveAssignments: false
 AlignConsecutiveDeclarations: false
 AlignEscapedNewlines: DontAlign
-# Requires clang 11 in Restyler
-#AlignOperands: AlignAfterOperator
-AlignOperands: true
+AlignOperands: AlignAfterOperator
 AlignTrailingComments: false
 AllowAllParametersOfDeclarationOnNextLine: true
 AllowShortLambdasOnASingleLine: None
@@ -144,9 +138,7 @@ BinPackArguments: true
 BinPackParameters: true
 BraceWrapping:
   AfterClass: false
-  # Requires clang 11 in Restyler
-  #AfterControlStatement: Never
-  AfterControlStatement: false
+  AfterControlStatement: Never
   AfterEnum: false
   AfterFunction: false
   AfterNamespace: false

--- a/.restyled.yaml
+++ b/.restyled.yaml
@@ -177,9 +177,12 @@ restylers_version: "20191031"
 #
 #   The command (and any required argument(s)) to perform the Restyling.
 #
+# for info see: https://github.com/restyled-io/restyler/issues/134
+# N.B. the docker image version can be controlled via PRs:
+# https://github.com/restyled-io/restylers/tree/main/clang-format
 restylers:
   - name: clang-format
-    image: restyled/restyler-clang-format:v10.0.0-2
+    image: 'restyled/restyler-clang-format:12.0.0'
     command:
       - clang-format
       - "-i"


### PR DESCRIPTION
for info: https://github.com/restyled-io/restyler/issues/134

N.B. the docker image version can be controlled via PRs: https://github.com/restyled-io/restylers/tree/main/clang-format