### PR TITLE
Update conan repo URL

### DIFF
--- a/cmake/Conan.cmake
+++ b/cmake/Conan.cmake
@@ -26,7 +26,7 @@ macro(run_conan)
     # Make sure to use conanfile.py to define dependencies, to stay consistent
     conan_cmake_run(
             REQUIRES
-            catch2/2.13.3
+            catch2/2.13.6
             fmt/7.1.3
             mp-units/0.7.0
             # refl-cpp/0.12.1 # could be used once there is a new release


### PR DESCRIPTION
 Change to new conan-center URL

Also add a message on how to import the current certificate root for conan versions older than 1.40.3.
See https://github.com/conan-io/conan/issues/9695#issuecomment-931406912.
An alternative would be to add `VERIFY_SSL False` to the `add_repository` command.

Updates catch2 to be compatible with gcc 11.2.0.

