### PR TITLE
added URI and MIME types

### DIFF
--- a/concepts/CMakeLists.txt
+++ b/concepts/CMakeLists.txt
@@ -1,1 +1,2 @@
+add_subdirectory(core)
 add_subdirectory(serialiser)

--- a/concepts/core/CMakeLists.txt
+++ b/concepts/core/CMakeLists.txt
@@ -1,0 +1,2 @@
+add_executable(URI_example URI_example.cpp)
+target_link_libraries(URI_example PRIVATE core project_options project_warnings)

--- a/concepts/core/URI_example.cpp
+++ b/concepts/core/URI_example.cpp
@@ -1,0 +1,39 @@
+#include <URI.hpp>
+#include <array>
+#include <iostream>
+
+/**
+ * simple example to illustrate uri syntax
+ */
+int main() {
+    opencmw::URI<> uri("mdp://User:notSoSecret@localhost.com:20/path/file.ext?queryString#cFrag");
+    fmt::print("scheme: '{}' authority: '{}'\n", uri.scheme(), uri.authority());
+    fmt::print("user: '{}' password: '{}' hostName: '{}' port: '{}'\n", uri.user(), uri.password(), uri.hostName(), uri.port());
+    fmt::print("path: '{}' query: '{}' fragment: '{}'\n", uri.path(), uri.queryParam(), uri.fragment());
+    std::cout << "std::ostream URI output: " << uri << '\n';
+    fmt::print("fmt::format URI output: {}\n", uri);
+
+    // URI factory examples
+    fmt::print("new URI: \"{}\"\n", opencmw::URI<>::factory(uri).build());
+
+    fmt::print("new URI: \"{}\"\n", opencmw::URI<>::factory().build());
+    fmt::print("new URI: \"{}\"\n", opencmw::URI<>::factory().setScheme("mdp").setAuthority("authority").build());
+    fmt::print("new URI: \"{}\"\n", opencmw::URI<>::factory().setScheme("mdp").setAuthority("authority").setPath("path").build());
+    fmt::print("new URI: \"{}\"\n", opencmw::URI<>::factory().setScheme("file").setPath("path").build());
+    fmt::print("new URI: \"{}\"\n", opencmw::URI<>::factory().setScheme("mdp").setHostName("localhost").setPort(8080).setPath("path").setQueryParam("key=value").setFragment("fragment").build());
+
+    // query parameter handling
+    fmt::print("new URI: \"{}\"\n", opencmw::URI<>::factory(uri).setQueryParam("").addQueryParameter("keyOnly").addQueryParameter("key", "value").build());
+    fmt::print("new URI: \"{}\"\n", opencmw::URI<>::factory(uri).addQueryParameter("keyOnly").addQueryParameter("key", "value").build());
+
+    opencmw::URI<> queryURI("http://User:notSoSecretPwd@localhost.com:20/path1/path2/path3/file.ext?k0&k1=v1;k2=v2&k3#cFrag");
+
+    // N.B. map usually defined via const auto map = ...
+    const std::unordered_map<std::string, std::optional<std::string>> &map = queryURI.queryParamMap();
+    for (const auto &[key, value] : map) {
+        // N.B. std::optional<T> are automatically unwrapped int printouts if value is present
+        fmt::print("map entry key={} value={}\n", key, value);
+    }
+
+    return 0;
+}

--- a/concepts/core/URI_example.cpp
+++ b/concepts/core/URI_example.cpp
@@ -14,17 +14,17 @@ int main() {
     fmt::print("fmt::format URI output: {}\n", uri);
 
     // URI factory examples
-    fmt::print("new URI: \"{}\"\n", opencmw::URI<>::factory(uri).build());
+    fmt::print("new URI: \"{}\"\n", opencmw::URI<>::factory(uri).toString());
 
-    fmt::print("new URI: \"{}\"\n", opencmw::URI<>::factory().build());
-    fmt::print("new URI: \"{}\"\n", opencmw::URI<>::factory().setScheme("mdp").setAuthority("authority").build());
-    fmt::print("new URI: \"{}\"\n", opencmw::URI<>::factory().setScheme("mdp").setAuthority("authority").setPath("path").build());
-    fmt::print("new URI: \"{}\"\n", opencmw::URI<>::factory().setScheme("file").setPath("path").build());
-    fmt::print("new URI: \"{}\"\n", opencmw::URI<>::factory().setScheme("mdp").setHostName("localhost").setPort(8080).setPath("path").setQueryParam("key=value").setFragment("fragment").build());
+    fmt::print("new URI: \"{}\"\n", opencmw::URI<>::factory().toString());
+    fmt::print("new URI: \"{}\"\n", opencmw::URI<>::factory().scheme("mdp").authority("authority").toString());
+    fmt::print("new URI: \"{}\"\n", opencmw::URI<>::factory().scheme("mdp").authority("authority").path("path").toString());
+    fmt::print("new URI: \"{}\"\n", opencmw::URI<>::factory().scheme("file").path("path").toString());
+    fmt::print("new URI: \"{}\"\n", opencmw::URI<>::factory().scheme("mdp").hostName("localhost").port(8080).path("path").queryParam("key=value").fragment("fragment").toString());
 
     // query parameter handling
-    fmt::print("new URI: \"{}\"\n", opencmw::URI<>::factory(uri).setQueryParam("").addQueryParameter("keyOnly").addQueryParameter("key", "value").build());
-    fmt::print("new URI: \"{}\"\n", opencmw::URI<>::factory(uri).addQueryParameter("keyOnly").addQueryParameter("key", "value").build());
+    fmt::print("new URI: \"{}\"\n", opencmw::URI<>::factory(uri).queryParam("").addQueryParameter("keyOnly").addQueryParameter("key", "value").toString());
+    fmt::print("new URI: \"{}\"\n", opencmw::URI<>::factory(uri).addQueryParameter("keyOnly").addQueryParameter("key", "value").toString());
 
     opencmw::URI<> queryURI("http://User:notSoSecretPwd@localhost.com:20/path1/path2/path3/file.ext?k0&k1=v1;k2=v2&k3#cFrag");
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,8 +1,8 @@
+add_subdirectory(core)
 add_subdirectory(utils)
 add_subdirectory(serialiser)
 add_subdirectory(majordomo/test)
 
-# add_subdirectory(core)
 # add_subdirectory(client)
 # add_subdirectory(server)
 # add_subdirectory(server-rest)

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -1,0 +1,16 @@
+# setup header only library
+add_library(core INTERFACE)
+target_include_directories(core INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include> $<INSTALL_INTERFACE:${CMAKE_INSTALL_PREFIX}/include/>)
+target_link_libraries(core INTERFACE CONAN_PKG::mp-units refl-cpp::refl-cpp utils)
+set_target_properties(core PROPERTIES PUBLIC_HEADER "include/URI.hpp;include/MIME.hpp")
+
+install(
+        TARGETS core
+        EXPORT opencmwTargets
+        PUBLIC_HEADER DESTINATION include/opencmw
+)
+
+# setup tests
+if(ENABLE_TESTING)
+  add_subdirectory(test)
+endif()

--- a/src/core/include/MIME.hpp
+++ b/src/core/include/MIME.hpp
@@ -1,4 +1,204 @@
 #ifndef OPENCMW_CPP_MIME_HPP
 #define OPENCMW_CPP_MIME_HPP
 
+#include <algorithm>
+#include <array>
+#include <cctype> // for tolower
+#include <iostream>
+#include <string_view>
+#include <vector>
+
+namespace opencmw::MIME {
+
+class MimeType {
+    static constexpr std::string_view   space = " ";
+    const std::string_view              _typeName;
+    const std::string_view              _description;
+    const std::vector<std::string_view> _fileExtensions;
+
+public:
+    MimeType() = delete;
+    template<class... Ts>
+    constexpr explicit MimeType(const char *name, const char *description, Ts... ext) noexcept
+        : _typeName(name), _description(description), _fileExtensions{ std::forward<Ts>(ext)... } {}
+    const std::string_view              typeName() const noexcept { return _typeName; }
+    const std::string_view              description() const noexcept { return _description; }
+    const std::vector<std::string_view> fileExtensions() const noexcept { return _fileExtensions; }
+
+    constexpr auto operator<=>(const MimeType &rhs) const noexcept { return _typeName <=> rhs._typeName; }
+    constexpr bool operator!=(const MimeType &rhs) const noexcept { return _typeName != rhs._typeName; }
+    constexpr bool operator==(const MimeType &rhs) const noexcept { return _typeName == rhs._typeName; }
+};
+
+/**
+ * Definition and convenience methods for common MIME types according to RFC6838 and RFC4855
+ * <p>
+ * Since the official list is rather long, contains types one may likely never encounter, and also does not contain all
+ * unofficial but nevertheless commonly used MIME types, we chose the specific sub-selection from:
+ * https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types
+ */
+/* text MIME types */
+static const MimeType CSS{ "text/css", "Cascading Style Sheets (CSS)", ".css" };
+static const MimeType CSV{ "text/csv", "Comma-separated values (CSV)", ".csv" };
+static const MimeType EVENT_STREAM{ "text/event-stream", "SSE stream" };
+static const MimeType HTML{ "text/html", "HyperText Markup Language (HTML)", ".htm", ".html" };
+static const MimeType ICS{ "text/calendar", "iCalendar format", ".ics" };
+static const MimeType JAVASCRIPT{ "text/javascript", "JavaScript", ".js", ".mjs" };
+static const MimeType JSON{ "application/json", "JSON format", ".json" };
+static const MimeType JSON_LD{ "application/ld+json", "JSON-LD format", ".jsonld" };
+static const MimeType TEXT{ "text/plain", "Text, (generally ASCII or ISO 8859-n)", ".txt" };
+static const MimeType XML{ "text/xml", "XML", ".xml" };                                        // if readable from casual users (RFC 3023, section 3)
+static const MimeType YAML{ "text/yaml", "YAML Ain't Markup Language File", ".yml", ".yaml" }; // not yet an IANA standard
+
+/* audio MIME types */
+static const MimeType AAC{ "audio/aac", "AAC audio", ".aac" };
+static const MimeType MIDI{ "audio/midi", "Musical Instrument Digital Interface (MIDI)", ".mid", ".midi" };
+static const MimeType MP3{ "audio/mpeg", "MP3 audio", ".mp3" };
+static const MimeType OTF{ "audio/opus", "Opus audio", ".opus" };
+static const MimeType WAV{ "audio/wav", "Waveform Audio Format", ".wav" };
+static const MimeType WEBM_AUDIO{ "audio/webm", "WEBM audio", ".weba" };
+
+/* image MIME types */
+static const MimeType BMP{ "image/bmp", "Windows OS/2 Bitmap Graphics", ".bmp" };
+static const MimeType GIF{ "image/gif", "Graphics Interchange Format (GIF)", ".gif" };
+static const MimeType ICO{ "image/vnd.microsoft.icon", "Icon format", ".ico" };
+static const MimeType JPEG{ "image/jpeg", "JPEG images", ".jpg", ".jpeg" };
+static const MimeType PNG{ "image/png", "Portable Network Graphics", ".png" };
+static const MimeType APNG{ "image/apng", "Portable Network Graphics", ".apng" }; // disabled ambiguous '.png' extension
+static const MimeType SVG{ "image/svg+xml", "Scalable Vector Graphics (SVG)", ".svg" };
+static const MimeType TIFF{ "image/tiff", "Tagged Image File Format (TIFF)", ".tif", ".tiff" };
+static const MimeType WEBP{ "image/webp", "WEBP image", ".webp" };
+
+/* video MIME types */
+static const MimeType AVI{ "video/x-msvideo", "AVI: Audio Video Interleave", ".avi" };
+static const MimeType MP2T{ "video/mp2t", "MPEG transport stream", ".ts" };
+static const MimeType MPEG{ "video/mpeg", "MPEG Video", ".mpeg" };
+static const MimeType WEBM_VIDEO{ "video/webm", "WEBM video", ".webm" };
+
+/* application-specific audio MIME types -- mostly binary-type formats */
+static const MimeType BINARY{ "application/octet-stream", "Any kind of binary data", ".bin" };
+static const MimeType CMWLIGHT{ "application/cmwlight", "proprietary CERN serialiser binary format", ".cmwlight" }; // deprecated: do not use for new projects
+// static const MimeType BZIP{"application/x-bzip", "BZip archive", ".bz"}; // affected by patent
+static const MimeType BZIP2{ "application/x-bzip2", "BZip2 archive", ".bz2" };
+static const MimeType DOC{ "application/msword", "Microsoft Word", ".doc" };
+static const MimeType DOCX{ "application/vnd.openxmlformats-officedocument.wordprocessingml.document", "Microsoft Word (OpenXML)", ".docx" };
+static const MimeType GZIP{ "application/gzip", "GZip Compressed Archive", ".gz" };
+static const MimeType JAR{ "application/java-archive", "Java Archive (JAR)", ".jar" };
+static const MimeType ODP{ "application/vnd.oasis.opendocument.presentation", "OpenDocument presentation document", ".odp" };
+static const MimeType ODS{ "application/vnd.oasis.opendocument.spreadsheet", "OpenDocument spreadsheet document", ".ods" };
+static const MimeType ODT{ "application/vnd.oasis.opendocument.text", "OpenDocument text document", ".odt" };
+static const MimeType OGG{ "application/ogg", "OGG Audio/Video File", ".ogx", ".ogv", ".oga" };
+static const MimeType PDF{ "application/pdf", "Adobe Portable Document Format (PDF)", ".pdf" };
+static const MimeType PHP{ "application/x-httpd-php", "Hypertext Preprocessor (Personal Home Page)", ".php" };
+static const MimeType PPT{ "application/vnd.ms-powerpoint", "Microsoft PowerPoint", ".ppt" };
+static const MimeType PPTX{ "application/vnd.openxmlformats-officedocument.presentationml.presentation", "Microsoft PowerPoint (OpenXML)", ".pptx" };
+static const MimeType RAR{ "application/vnd.rar", "RAR archive", ".rar" };
+static const MimeType RTF{ "application/rtf", "Rich Text Format (RTF)", ".rtf" };
+static const MimeType TAR{ "application/x-tar", "Tape Archive (TAR)", ".tar" };
+static const MimeType VSD{ "application/vnd.visio", "Microsoft Visio", ".vsd" };
+static const MimeType XHTML{ "application/xhtml+xml", "XHTML", ".xhtml" };
+static const MimeType XLS{ "application/vnd.ms-excel", "Microsoft Excel", ".xls" };
+static const MimeType XLSX{ "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", "Microsoft Excel (OpenXML)", ".xlsx" };
+static const MimeType ZIP{ "application/zip", "ZIP archive", ".zip" };
+/* fall-back */
+static const MimeType                  UNKNOWN{ "unknown/unknown", "unknown data format" };
+
+static inline std::array<MimeType, 54> ALL{
+    // text MIME types
+    CSS, CSV, EVENT_STREAM, HTML, ICS, JAVASCRIPT, JSON, JSON_LD, TEXT, XML, YAML,
+    // audio MIME types
+    AAC, MIDI, MP3, OTF, WAV, WEBM_AUDIO,
+    // image MIME types
+    BMP, GIF, ICO, JPEG, PNG, APNG, SVG, TIFF, WEBP,
+    // video MIME types
+    AVI, MP2T, MPEG, WEBM_VIDEO,
+    // application-specific audio MIME types -- mostly binary-type formats
+    BINARY, CMWLIGHT, BZIP2, DOC, DOCX, GZIP, JAR, ODP, ODS, ODT, OGG, PDF, PHP, PPT, PPTX, RAR, RTF, TAR, VSD, XHTML, XLS, XLSX, ZIP,
+    // unknown category
+    UNKNOWN
+};
+
+/**
+ * Case-insensitive mapping between MIME-type string and enumumeration value.
+ *
+ * @param mimeTypeStr the string equivalent mime-type, e.g. "image/png"
+ * @return the enumeration equivalent first matching mime-type, e.g. MimeType.PNG or MimeType.UNKNOWN as fall-back
+ */
+const static MimeType &getType(const std::string_view &mimeTypeStr) {
+    if (mimeTypeStr.empty()) {
+        return UNKNOWN;
+    }
+    std::string mimeType(mimeTypeStr);
+    std::transform(mimeType.begin(), mimeType.end(), mimeType.begin(), static_cast<int (*)(int)>(std::tolower));
+    for (MimeType &mType : ALL) {
+        // N.B.mimeType can contain several MIME types, e.g "image/webp,image/apng,image/*"
+        if (mimeType.find(mType.typeName()) != std::string::npos) {
+            return mType;
+        }
+    }
+    return UNKNOWN;
+}
+
+/**
+ * Case-insensitive mapping between MIME-type string and enumeration value.
+ *
+ * @param fileName the string equivalent mime-type, e.g. "image/png"
+ * @return the enumeration equivalent mime-type, e.g. MimeType.PNG or MimeType.UNKNOWN as fall-back
+ */
+const static MimeType &getTypeByFileName(const std::string_view &fileName) {
+    if (fileName.empty()) {
+        return UNKNOWN;
+    }
+    constexpr auto ends_with = [](const std::string_view &value, const std::string_view &ending) {
+        return ending.size() > value.size() ? false : std::equal(ending.rbegin(), ending.rend(), value.rbegin());
+    };
+    std::string trimmed(fileName);
+    std::transform(trimmed.begin(), trimmed.end(), trimmed.begin(), static_cast<int (*)(int)>(std::tolower));
+
+    for (MimeType &mType : ALL) {
+        for (auto &ending : mType.fileExtensions()) {
+            if (ends_with(trimmed, ending)) {
+                return mType;
+            }
+        }
+    }
+
+    return UNKNOWN;
+}
+
+} /* namespace opencmw::MIME */
+
+template<typename T>
+inline std::ostream &operator<<(std::ostream &os, const std::vector<T> &v) {
+    os << '[';
+    bool first = true;
+    for (auto t : v) {
+        if (first) {
+            os << t;
+            first = false;
+        } else {
+            os << ", ";
+            os << t;
+        }
+    }
+    return os << ']';
+}
+
+template<>
+struct fmt::formatter<opencmw::MIME::MimeType> {
+            template<typename ParseContext>
+            constexpr auto parse(ParseContext &ctx) {
+                return ctx.begin(); // not (yet) implemented
+            }
+
+            template<typename FormatContext>
+            auto format(opencmw::MIME::MimeType const &v, FormatContext &ctx) {
+                return fmt::format_to(ctx.out(), "{}", v.typeName());
+            }
+        };
+
+inline std::ostream &operator<<(std::ostream &os, const opencmw::MIME::MimeType &v) {
+    return os << v.typeName();
+}
+
 #endif // OPENCMW_CPP_MIME_HPP

--- a/src/core/include/MIME.hpp
+++ b/src/core/include/MIME.hpp
@@ -25,9 +25,9 @@ public:
     const std::string_view              description() const noexcept { return _description; }
     const std::vector<std::string_view> fileExtensions() const noexcept { return _fileExtensions; }
 
-    constexpr auto operator<=>(const MimeType &rhs) const noexcept { return _typeName <=> rhs._typeName; }
-    constexpr bool operator!=(const MimeType &rhs) const noexcept { return _typeName != rhs._typeName; }
-    constexpr bool operator==(const MimeType &rhs) const noexcept { return _typeName == rhs._typeName; }
+    constexpr auto                      operator<=>(const MimeType &rhs) const noexcept { return _typeName <=> rhs._typeName; }
+    constexpr bool                      operator!=(const MimeType &rhs) const noexcept { return _typeName != rhs._typeName; }
+    constexpr bool                      operator==(const MimeType &rhs) const noexcept { return _typeName == rhs._typeName; }
 };
 
 /**
@@ -186,16 +186,16 @@ inline std::ostream &operator<<(std::ostream &os, const std::vector<T> &v) {
 
 template<>
 struct fmt::formatter<opencmw::MIME::MimeType> {
-            template<typename ParseContext>
-            constexpr auto parse(ParseContext &ctx) {
-                return ctx.begin(); // not (yet) implemented
-            }
+    template<typename ParseContext>
+    constexpr auto parse(ParseContext &ctx) {
+        return ctx.begin(); // not (yet) implemented
+    }
 
-            template<typename FormatContext>
-            auto format(opencmw::MIME::MimeType const &v, FormatContext &ctx) {
-                return fmt::format_to(ctx.out(), "{}", v.typeName());
-            }
-        };
+    template<typename FormatContext>
+    auto format(opencmw::MIME::MimeType const &v, FormatContext &ctx) {
+        return fmt::format_to(ctx.out(), "{}", v.typeName());
+    }
+};
 
 inline std::ostream &operator<<(std::ostream &os, const opencmw::MIME::MimeType &v) {
     return os << v.typeName();

--- a/src/core/include/MIME.hpp
+++ b/src/core/include/MIME.hpp
@@ -1,0 +1,4 @@
+#ifndef OPENCMW_CPP_MIME_HPP
+#define OPENCMW_CPP_MIME_HPP
+
+#endif // OPENCMW_CPP_MIME_HPP

--- a/src/core/include/MIME.hpp
+++ b/src/core/include/MIME.hpp
@@ -26,7 +26,6 @@ public:
     const std::vector<std::string_view> fileExtensions() const noexcept { return _fileExtensions; }
 
     constexpr auto                      operator<=>(const MimeType &rhs) const noexcept { return _typeName <=> rhs._typeName; }
-    constexpr bool                      operator!=(const MimeType &rhs) const noexcept { return _typeName != rhs._typeName; }
     constexpr bool                      operator==(const MimeType &rhs) const noexcept { return _typeName == rhs._typeName; }
 };
 
@@ -101,9 +100,9 @@ static const MimeType XLS{ "application/vnd.ms-excel", "Microsoft Excel", ".xls"
 static const MimeType XLSX{ "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", "Microsoft Excel (OpenXML)", ".xlsx" };
 static const MimeType ZIP{ "application/zip", "ZIP archive", ".zip" };
 /* fall-back */
-static const MimeType                  UNKNOWN{ "unknown/unknown", "unknown data format" };
+static const MimeType    UNKNOWN{ "unknown/unknown", "unknown data format" };
 
-static inline std::array<MimeType, 54> ALL{
+static inline std::array ALL{
     // text MIME types
     CSS, CSV, EVENT_STREAM, HTML, ICS, JAVASCRIPT, JSON, JSON_LD, TEXT, XML, YAML,
     // audio MIME types
@@ -130,10 +129,10 @@ const static MimeType &getType(const std::string_view &mimeTypeStr) {
     }
     std::string mimeType(mimeTypeStr);
     std::transform(mimeType.begin(), mimeType.end(), mimeType.begin(), static_cast<int (*)(int)>(std::tolower));
-    for (MimeType &mType : ALL) {
+    for (const MimeType &type : ALL) {
         // N.B.mimeType can contain several MIME types, e.g "image/webp,image/apng,image/*"
-        if (mimeType.find(mType.typeName()) != std::string::npos) {
-            return mType;
+        if (mimeType.find(type.typeName()) != std::string::npos) {
+            return type;
         }
     }
     return UNKNOWN;
@@ -150,15 +149,15 @@ const static MimeType &getTypeByFileName(const std::string_view &fileName) {
         return UNKNOWN;
     }
     constexpr auto ends_with = [](const std::string_view &value, const std::string_view &ending) {
-        return ending.size() > value.size() ? false : std::equal(ending.rbegin(), ending.rend(), value.rbegin());
+        return ending.size() <= value.size() ? std::equal(ending.rbegin(), ending.rend(), value.rbegin()) : false;
     };
     std::string trimmed(fileName);
     std::transform(trimmed.begin(), trimmed.end(), trimmed.begin(), static_cast<int (*)(int)>(std::tolower));
 
-    for (MimeType &mType : ALL) {
-        for (auto &ending : mType.fileExtensions()) {
+    for (const MimeType &type : ALL) {
+        for (const auto &ending : type.fileExtensions()) {
             if (ends_with(trimmed, ending)) {
-                return mType;
+                return type;
             }
         }
     }

--- a/src/core/include/URI.hpp
+++ b/src/core/include/URI.hpp
@@ -294,17 +294,17 @@ public:
             if (!uri._query.empty())     { _query = uri._query; }
             if (!uri._fragment.empty())  { _fragment = uri._fragment; }
         }
-        inline UriFactory& scheme(const std::string_view &scheme)        noexcept { _scheme = { scheme.begin(), scheme.end() }; return *this; }
-        inline UriFactory& authority(const std::string_view &authority)  noexcept { _authority = { authority.begin(), authority.end() }; return *this; }
-        inline UriFactory& user(const std::string_view &userName)        noexcept { _userName = { userName.begin(), userName.end() }; return *this; }
-        inline UriFactory& password(const std::string_view &pwd)         noexcept { _pwd = { pwd.begin(), pwd.end() }; return *this; }
-        inline UriFactory& hostName(const std::string_view &hostName)    noexcept { _host = { hostName.begin(), hostName.end() }; return *this; }
-        inline UriFactory& port(const uint16_t port)                     noexcept { _port = std::optional<uint16_t>(port); return *this; }
-        inline UriFactory& path(const std::string_view &path)            noexcept { _path = { path.begin(), path.end() }; return *this; }
-        inline UriFactory& queryParam(const std::string_view &query)     noexcept { _query = { query.begin(), query.end() }; return *this; }
-        inline UriFactory& fragment(const std::string_view &fragment)    noexcept { _fragment = { fragment.begin(), fragment.end() }; return *this; }
-        inline UriFactory& addQueryParameter(const std::string &key)     noexcept { _queryMap[key] = std::nullopt; return *this; }
-        inline UriFactory& addQueryParameter(const std::string &key, const std::string &value) noexcept { _queryMap[key] = std::optional(value); return *this; }
+        inline UriFactory&& scheme(const std::string_view &scheme)        noexcept { _scheme = { scheme.begin(), scheme.end() }; return std::move(*this); }
+        inline UriFactory&& authority(const std::string_view &authority)  noexcept { _authority = { authority.begin(), authority.end() }; return std::move(*this); }
+        inline UriFactory&& user(const std::string_view &userName)        noexcept { _userName = { userName.begin(), userName.end() }; return std::move(*this); }
+        inline UriFactory&& password(const std::string_view &pwd)         noexcept { _pwd = { pwd.begin(), pwd.end() }; return std::move(*this); }
+        inline UriFactory&& hostName(const std::string_view &hostName)    noexcept { _host = { hostName.begin(), hostName.end() }; return std::move(*this); }
+        inline UriFactory&& port(const uint16_t port)                     noexcept { _port = std::optional<uint16_t>(port); return std::move(*this); }
+        inline UriFactory&& path(const std::string_view &path)            noexcept { _path = { path.begin(), path.end() }; return std::move(*this); }
+        inline UriFactory&& queryParam(const std::string_view &query)     noexcept { _query = { query.begin(), query.end() }; return std::move(*this); }
+        inline UriFactory&& fragment(const std::string_view &fragment)    noexcept { _fragment = { fragment.begin(), fragment.end() }; return std::move(*this); }
+        inline UriFactory&& addQueryParameter(const std::string &key)     noexcept { _queryMap[key] = std::nullopt; return std::move(*this); }
+        inline UriFactory&& addQueryParameter(const std::string &key, const std::string &value) noexcept { _queryMap[key] = std::optional(value); return std::move(*this); }
         // clang-format on
 
         std::string toString() {

--- a/src/core/include/URI.hpp
+++ b/src/core/include/URI.hpp
@@ -1,0 +1,379 @@
+#ifndef OPENCMW_CPP_URI_HPP
+#define OPENCMW_CPP_URI_HPP
+#include <algorithm>
+#include <fmt/format.h>
+#include <iomanip>
+#include <ios>
+#include <optional>
+#include <sstream>
+#include <string>
+#include <string_view>
+
+namespace opencmw {
+
+struct URISyntaxException : public std::ios_base::failure {
+    explicit URISyntaxException()
+        : std::ios_base::failure("unknown URI exception") {}
+    explicit URISyntaxException(const std::string &errorMsg)
+        : std::ios_base::failure(errorMsg) {}
+    explicit URISyntaxException(const char *errorMsg)
+        : std::ios_base::failure(errorMsg) {}
+};
+
+enum uri_check {
+    STRICT, // checks for RFC-3986-restricted ascii-characters only and throws exception if violated
+    RELAXED // checks for RFC-3986-restricted only
+};
+
+// parse RFC 3986 URIs of the form [scheme:][//authority][/path][?query parameter][#fragment]
+// authority can be [<user>[:password]@]<host>[:port]
+// simple parser for internal use (N.B. does handle all nominal but not necessarily all corner-failure-cases)
+// compiler-explorer test: https://compiler-explorer.com/z/a7W3eosYM
+// regex test: regexr.com/69hv8
+template<uri_check check = STRICT>
+class URI {
+    using string      = std::string;
+    using string_view = std::string_view;
+    // need to keep a local, owning, and immutable copy of the source template
+    const string _localCopy;
+    // evaluate on demand and if available
+    string_view         _scheme;
+    string_view         _authority;
+    mutable bool        _parsedAuthority = false;
+    mutable string_view _userName;
+    mutable string_view _pwd;
+    mutable string_view _hostName;
+    mutable string_view _port;
+    string_view         _path;
+    string_view         _query;
+    string_view         _fragment;
+
+    // computed on-demand
+    std::unordered_map<string, std::optional<string>> _queryMap;
+    // simple optional un-wrapper
+    inline const std::optional<string> returnOpt(const string_view &src) const noexcept { return src.empty() ? std::nullopt : std::optional(string{ src.begin(), src.end() }); };
+
+protected:
+    // returns tif only RFC 3986 section 2.3 Unreserved Characters
+    static constexpr inline bool isUnreserved(const char c) noexcept { return std::isalnum(c) || c == '-' || c == '_' || c == '.' || c == '~'; }
+    constexpr inline void        parseAuthority() const {
+        if (_parsedAuthority || _authority.empty()) {
+            _parsedAuthority = true;
+            return;
+        }
+        size_t userSplit = std::min(_authority.find_first_of('@'), _authority.length());
+        if (userSplit != string_view::npos && userSplit < _authority.length()) {
+            // user isUnreserved defined via '[user]:[pwd]@'
+            const size_t pwdSplit = std::min(_authority.find_first_of(':'), userSplit);
+            _userName             = _authority.substr(0, pwdSplit);
+            if (pwdSplit < userSplit) {
+                _pwd = _authority.substr(pwdSplit + 1, userSplit - pwdSplit - 1);
+            }
+            userSplit++;
+        } else {
+            userSplit = 0;
+        }
+        size_t portSplit = std::min(_authority.find_first_of(':', userSplit), _authority.length());
+        if (portSplit != string_view::npos && portSplit < _authority.length()) {
+            // port defined
+            _hostName = _authority.substr(userSplit, portSplit - userSplit);
+            portSplit++;
+            _port = _authority.substr(portSplit, _authority.length() - portSplit);
+        } else {
+            _hostName = _authority.substr(userSplit, _authority.length() - userSplit);
+        }
+    }
+
+public:
+    URI() = delete;
+    explicit URI(const string_view &src)
+        : _localCopy{ src } {
+        string_view source(_localCopy.c_str(), _localCopy.size());
+        if constexpr (check == STRICT) {
+            constexpr auto validURICharacters = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~:/?#[]@!$&'()*+,;=%";
+            unsigned long  illegalChar        = source.find_first_not_of(validURICharacters);
+            if (illegalChar != std::string::npos) {
+                throw URISyntaxException(fmt::format("URI contains illegal characters: {} at position {} of {}", source, illegalChar, source.length()));
+            }
+        }
+
+        // check for scheme
+        size_t scheme_size = source.find_first_of(':', 0);
+        if (scheme_size != string::npos) {
+            _scheme = source.substr(0, scheme_size);
+            if constexpr (check == STRICT) {
+                if (!std::all_of(_scheme.begin(), _scheme.end(), [](char c) { return std::isalnum(c); })) {
+                    throw URISyntaxException(fmt::format("URI scheme contains illegal characters: {}", _scheme));
+                }
+            }
+            scheme_size++;
+        } else {
+            scheme_size = 0L;
+        }
+
+        // check for authority
+        size_t authOffset = scheme_size;
+        size_t authEnd    = scheme_size;
+        if (authEnd == source.length()) {
+            return; // nothing more to parse
+        }
+        if ((source[scheme_size] == '/' && source[scheme_size + 1] == '/' && source.length() > authOffset)
+                || (scheme_size == 0 && source[scheme_size] != '/' && source[scheme_size] != '?' && source[scheme_size] != '#')) {
+            // authority isUnreserved defined starting with '//'
+            authOffset += 2;
+            authEnd    = std::min(source.find_first_of("/?#\0", authOffset), source.length());
+            _authority = source.substr(authOffset, authEnd - authOffset);
+            if constexpr (check == STRICT) {
+                if (!std::all_of(_authority.begin(), _authority.end(), [](char c) { return std::isalnum(c) || c == '@' || c == ':' || c == '.' || c == '-' || c == '_'; })) {
+                    throw URISyntaxException(fmt::format("URI authority contains illegal characters: {}", _authority));
+                }
+            }
+            // lazy parsing of authority in parseAuthority()
+        } else {
+            authEnd = scheme_size;
+        }
+
+        size_t pathEnd = std::min(source.find_first_of("?#", authEnd), source.length());
+        if (pathEnd != string_view::npos && pathEnd <= source.length()) {
+            _path = source.substr(authEnd, pathEnd - authEnd);
+            if constexpr (check == STRICT) {
+                if (!std::all_of(_path.begin(), _path.end(), [](char c) { return std::isalnum(c) || c == '/' || c == '.' || c == '-' || c == '_'; })) {
+                    throw URISyntaxException(fmt::format("URI path contains illegal characters: {}", _path));
+                }
+            }
+        } else {
+            // no path info
+        }
+        if (pathEnd == source.length()) {
+            return; // nothing more to parse
+        }
+        size_t queryEnd = std::min(source.find_first_of('#', pathEnd), source.length());
+        if (source[pathEnd] == '?' && queryEnd != string_view::npos && queryEnd <= source.length()) {
+            _query = source.substr(pathEnd + 1, queryEnd - pathEnd - 1);
+        } else {
+            // no query present
+            queryEnd = pathEnd;
+        }
+        if (queryEnd == source.length()) {
+            return; // nothing more to parse
+        }
+        size_t fragStart = source.find_first_of('#', queryEnd);
+        if (fragStart != string_view::npos && fragStart < source.length()) {
+            fragStart++;
+            _fragment = source.substr(fragStart, source.length() - fragStart);
+        }
+    }
+
+    static std::string encode(const std::string_view &source) noexcept {
+        std::ostringstream encoded;
+        encoded.fill('0');
+        encoded << std::hex;
+
+        for (auto c : source) {
+            if (isUnreserved(c)) {
+                // keep RFC 3986 section 2.3 Unreserved Characters i.e. [a-zA-Z0-9-_-~]
+                encoded << c;
+            } else {
+                // percent-encode RFC 3986 section 2.2 Reserved Characters i.e. [!#$%&'()*+,/:;=?@[]]
+                encoded << std::uppercase;
+                encoded << '%' << std::setw(2) << int(static_cast<uint8_t>(c));
+                encoded << std::nouppercase;
+            }
+        }
+
+        return encoded.str();
+    }
+
+    static std::string decode(const std::string_view &s) {
+        std::ostringstream decoded;
+        for (size_t i = 0; i < s.size(); ++i) {
+            char c = s[i];
+            if (isUnreserved(c)) {
+                // keep RFC 3986 section 2.3 Unreserved Characters i.e. [a-zA-Z0-9-_-~]
+                decoded << c;
+            } else if (c == '%') {
+                // percent-encode RFC 3986 section 2.2 Reserved Characters i.e. [!#$%&'()*+,/:;=?@[]]
+                if constexpr (check == STRICT) {
+                    if (!std::isxdigit(s[i + 1])) {
+                        throw URISyntaxException(fmt::format("additional erroneous character '{}' found after '%' at {} of '{}'", s[i + 1], i + 1, s));
+                    }
+                }
+                int                d;
+                std::istringstream iss(string(s.substr(i + 1, 2))); // TODO find smarter conversion
+                iss >> std::hex >> d;
+                decoded << static_cast<uint8_t>(d);
+                i += 2;
+            }
+        }
+        return decoded.str();
+    }
+
+    // clang-format off
+    inline const std::optional<string> scheme() const noexcept { return returnOpt(_scheme); }
+    inline const std::optional<string> authority() const noexcept { return returnOpt(_authority); }
+    inline const std::optional<string> user() const noexcept { parseAuthority(); return returnOpt(_userName); }
+    inline const std::optional<string> password() const noexcept { parseAuthority(); return returnOpt(_pwd); }
+    inline const std::optional<string> hostName() const noexcept { parseAuthority(); return returnOpt(_hostName); }
+    inline const std::optional<uint16_t> port() const noexcept { parseAuthority(); return _port.empty() ? std::nullopt : std::optional(std::stoi(string{ _port.begin(), _port.end() }));}
+    inline const std::optional<string> path() const noexcept { return returnOpt(_path); }
+    inline const std::optional<string> queryParam() const noexcept { return returnOpt(_query); }
+    inline const std::optional<string> fragment() const noexcept { return returnOpt(_fragment); }
+    // clang-format om
+
+    // decompose map
+    inline const std::unordered_map<string, std::optional<string>> &queryParamMap() {
+        if (_query.empty() || !_queryMap.empty()) { // empty query parameter or already parsed
+            return _queryMap;
+        }
+        if constexpr (check == STRICT) {
+            if (!std::all_of(_query.begin(), _query.end(), [](char c) { return isUnreserved(c) || c == '&' || c == ';' || c == '=' || c == '%'; })) {
+                throw std::exception(); // TODO: URIException("URI query contains illegal characters: {}")
+            }
+        }
+        size_t readPos = 0;
+        while (readPos < _query.length()) {
+            auto keyEnd = _query.find_first_of("=;&\0", readPos);
+            if (keyEnd != string_view::npos && keyEnd < _query.length()) {
+                auto key = decode(_query.substr(readPos, keyEnd - readPos));
+                if (_query[keyEnd] != '=') {
+                    _queryMap[key] = std::nullopt;
+                    readPos        = keyEnd + 1; //+1 for separator character
+                    continue;
+                }
+                readPos = keyEnd + 1; // skip equal after '='
+                // equal sign present
+                if (readPos >= _query.length()) {
+                    // reached parameter string end
+                    break;
+                }
+                const auto valueEnd = _query.find_first_of(";&\0", readPos);
+                if (valueEnd != string_view::npos && valueEnd < _query.length()) {
+                    _queryMap[key] = std::optional(decode(_query.substr(readPos, valueEnd - readPos)));
+                    readPos        = valueEnd + 1;
+                    continue;
+                }
+                _queryMap[key] = std::optional(decode(_query.substr(readPos, _query.length() - readPos)));
+            } else {
+                auto key       = std::string(_query.substr(readPos, _query.length() - readPos));
+                _queryMap[key] = std::nullopt;
+                break;
+            }
+        }
+
+        return _queryMap;
+    };
+
+    // default operator overloading
+    auto operator<=>(const URI &) const noexcept = default; // TODO: may need to implement custom
+    bool operator!=(const URI &) const noexcept  = default;
+
+    class UriFactory {
+        string                  _authority;
+        string                  _scheme;
+        string                  _userName;
+        string                  _pwd;
+        string                  _host;
+        std::optional<uint16_t> _port;
+        string                  _path;
+        string                  _query;
+        string                  _fragment;
+        // local map to overwrite _query parameter if set
+        std::unordered_map<string, std::optional<string>> _queryMap;
+
+    public:
+        UriFactory() = default;
+        // clang-format off
+        explicit UriFactory(const URI &uri) {
+            if (!uri._scheme.empty())    { _scheme = uri._scheme; }
+            if (!uri._authority.empty()) { _authority = uri._authority; }
+            if (!uri._userName.empty())  { _userName = uri._userName; }
+            if (!uri._pwd.empty())       { _pwd = uri._pwd; }
+            if (!uri._hostName.empty())  { _host = uri._hostName; }
+            if (!uri._port.empty())      { _port = std::stoi(std::string(uri._port)); }
+            if (!uri._path.empty())      { _path = uri._path; }
+            if (!uri._query.empty())     { _query = uri._query; }
+            if (!uri._fragment.empty())  { _fragment = uri._fragment; }
+        }
+        inline UriFactory setScheme(const std::string_view &scheme)        noexcept { _scheme = { scheme.begin(), scheme.end() }; return *this; }
+        inline UriFactory setAuthority(const std::string_view &authority)  noexcept { _authority = { authority.begin(), authority.end() }; return *this; }
+        inline UriFactory setUser(const std::string_view &userName)        noexcept { _userName = { userName.begin(), userName.end() }; return *this; }
+        inline UriFactory setPassword(const std::string_view &pwd)         noexcept { _pwd = { pwd.begin(), pwd.end() }; return *this; }
+        inline UriFactory setHostName(const std::string_view &hostName)    noexcept { _host = { hostName.begin(), hostName.end() }; return *this; }
+        inline UriFactory setPort(const uint16_t port)                     noexcept { _port = std::optional<uint16_t>(port); return *this; }
+        inline UriFactory setPath(const std::string_view &path)            noexcept { _path = { path.begin(), path.end() }; return *this; }
+        inline UriFactory setQueryParam(const std::string_view &query)     noexcept { _query = { query.begin(), query.end() }; return *this; }
+        inline UriFactory setFragment(const std::string_view &fragment)    noexcept { _fragment = { fragment.begin(), fragment.end() }; return *this; }
+        inline UriFactory addQueryParameter(const std::string key)         noexcept { _queryMap[key] = std::nullopt; return *this; }
+        inline UriFactory addQueryParameter(const std::string key, const std::string value) noexcept { _queryMap[key] = std::optional(value); return *this; }
+        // clang-format on
+
+        std::string build() {
+            using namespace fmt::literals;
+            if (_authority.empty()) {
+                _authority = fmt::format("{user}{opt_colon1}{pwd}{at}{host}{opt_colon2}{port}",                //
+                        "user"_a = _userName, "opt_colon1"_a = (_pwd.empty() || _userName.empty()) ? "" : ":", /* user:pwd colon separator */
+                        "pwd"_a = _userName.empty() ? "" : _pwd, "at"_a = _userName.empty() ? "" : "@",        // 'user:pwd@' separator
+                        "host"_a = _host, "opt_colon2"_a = _port ? ":" : "", "port"_a = _port ? std::to_string(_port.value()) : "");
+            }
+
+            for (const auto &[key, value] : _queryMap) {
+                _query += fmt::format("{opt_ampersand}{key}{opt_equal}{value}",               // N.B. 'key=value' percent-encoding according to RFC 3986
+                        "opt_ampersand"_a = _query.empty() ? "" : "&", "key"_a = encode(key), //
+                        "opt_equal"_a = value ? "=" : "", "value"_a = value ? encode(value.value()) : "");
+            }
+
+            return fmt::format("{scheme}{colon}{opt_auth_slash}{authority}{opt_path_slash}{path}{qMark}{query}{hashMark}{fragment}",   //
+                    "scheme"_a = _scheme, "colon"_a = _scheme.empty() ? "" : ":",                                                      // scheme
+                    "opt_auth_slash"_a = (_authority.empty() || _authority.starts_with("//")) ? "" : "//", "authority"_a = _authority, // authority
+                    "opt_path_slash"_a = (_path.empty() || _path.starts_with('/') || _authority.empty()) ? "" : "/", "path"_a = _path, // path
+                    "qMark"_a = (_query.empty() || _query.starts_with('?')) ? "" : "?", "query"_a = _query,                            // query
+                    "hashMark"_a = (_fragment.empty() || _fragment.starts_with('#')) ? "" : "#", "fragment"_a = encode(_fragment));    // fragment
+        }
+    };
+
+    static inline UriFactory factory() noexcept { return UriFactory(); }
+    static inline UriFactory factory(const URI &uri) noexcept { return UriFactory(uri); }
+};
+} // namespace opencmw
+
+// fmt::format and std::ostream helper output
+
+// fmt::format and std::ostream helper output for std::optional
+template<typename T> // TODO: move to utils class
+struct fmt::formatter<std::optional<T>> {
+    template<typename ParseContext>
+    constexpr auto parse(ParseContext &ctx) {
+        return ctx.begin(); // not (yet) implemented
+    }
+
+    template<typename FormatContext>
+    auto format(std::optional<T> const &v, FormatContext &ctx) {
+        return v ? fmt::format_to(ctx.out(), "{}", v.value()) : fmt::format_to(ctx.out(), "<std::nullopt>"); // TODO: check alt of '<>' or ''
+    }
+};
+
+template<typename T>
+inline std::ostream &operator<<(std::ostream &os, const std::optional<T> &v) {
+    return os << fmt::format("{}", v);
+}
+
+template<opencmw::uri_check check>
+struct fmt::formatter<opencmw::URI<check>> {
+    template<typename ParseContext>
+    constexpr auto parse(ParseContext &ctx) {
+        return ctx.begin(); // not (yet) implemented
+    }
+
+    template<typename FormatContext>
+    auto format(opencmw::URI<check> const &v, FormatContext &ctx) {
+        return fmt::format_to(ctx.out(), "{{scheme: '{}', authority: '{}', user: '{}', pwd: '{}', host: '{}', port: '{}', path: '{}', query: '{}', fragment: '{}'}}", //
+                v.scheme(), v.authority(), v.user(), v.password(), v.hostName(), v.port(), v.path(), v.queryParam(), v.fragment());
+    }
+};
+
+template<opencmw::uri_check check>
+inline std::ostream &operator<<(std::ostream &os, const opencmw::URI<check> &v) {
+    return os << fmt::format("{}", v);
+}
+
+#endif // OPENCMW_CPP_URI_HPP

--- a/src/core/include/URI.hpp
+++ b/src/core/include/URI.hpp
@@ -294,17 +294,17 @@ public:
             if (!uri._query.empty())     { _query = uri._query; }
             if (!uri._fragment.empty())  { _fragment = uri._fragment; }
         }
-        inline UriFactory&& scheme(const std::string_view &scheme)        noexcept { _scheme = { scheme.begin(), scheme.end() }; return std::move(*this); }
-        inline UriFactory&& authority(const std::string_view &authority)  noexcept { _authority = { authority.begin(), authority.end() }; return std::move(*this); }
-        inline UriFactory&& user(const std::string_view &userName)        noexcept { _userName = { userName.begin(), userName.end() }; return std::move(*this); }
-        inline UriFactory&& password(const std::string_view &pwd)         noexcept { _pwd = { pwd.begin(), pwd.end() }; return std::move(*this); }
-        inline UriFactory&& hostName(const std::string_view &hostName)    noexcept { _host = { hostName.begin(), hostName.end() }; return std::move(*this); }
-        inline UriFactory&& port(const uint16_t port)                     noexcept { _port = std::optional<uint16_t>(port); return std::move(*this); }
-        inline UriFactory&& path(const std::string_view &path)            noexcept { _path = { path.begin(), path.end() }; return std::move(*this); }
-        inline UriFactory&& queryParam(const std::string_view &query)     noexcept { _query = { query.begin(), query.end() }; return std::move(*this); }
-        inline UriFactory&& fragment(const std::string_view &fragment)    noexcept { _fragment = { fragment.begin(), fragment.end() }; return std::move(*this); }
-        inline UriFactory&& addQueryParameter(const std::string &key)     noexcept { _queryMap[key] = std::nullopt; return std::move(*this); }
-        inline UriFactory&& addQueryParameter(const std::string &key, const std::string &value) noexcept { _queryMap[key] = std::optional(value); return std::move(*this); }
+        inline UriFactory&& scheme(const std::string_view &scheme)        && noexcept { _scheme = { scheme.begin(), scheme.end() }; return std::move(*this); }
+        inline UriFactory&& authority(const std::string_view &authority)  && noexcept { _authority = { authority.begin(), authority.end() }; return std::move(*this); }
+        inline UriFactory&& user(const std::string_view &userName)        && noexcept { _userName = { userName.begin(), userName.end() }; return std::move(*this); }
+        inline UriFactory&& password(const std::string_view &pwd)         && noexcept { _pwd = { pwd.begin(), pwd.end() }; return std::move(*this); }
+        inline UriFactory&& hostName(const std::string_view &hostName)    && noexcept { _host = { hostName.begin(), hostName.end() }; return std::move(*this); }
+        inline UriFactory&& port(const uint16_t port)                     && noexcept { _port = std::optional<uint16_t>(port); return std::move(*this); }
+        inline UriFactory&& path(const std::string_view &path)            && noexcept { _path = { path.begin(), path.end() }; return std::move(*this); }
+        inline UriFactory&& queryParam(const std::string_view &query)     && noexcept { _query = { query.begin(), query.end() }; return std::move(*this); }
+        inline UriFactory&& fragment(const std::string_view &fragment)    && noexcept { _fragment = { fragment.begin(), fragment.end() }; return std::move(*this); }
+        inline UriFactory&& addQueryParameter(const std::string &key)     && noexcept { _queryMap[key] = std::nullopt; return std::move(*this); }
+        inline UriFactory&& addQueryParameter(const std::string &key, const std::string &value) && noexcept { _queryMap[key] = std::optional(value); return std::move(*this); }
         // clang-format on
 
         std::string toString() {

--- a/src/core/test/CMakeLists.txt
+++ b/src/core/test/CMakeLists.txt
@@ -1,0 +1,7 @@
+include(CTest)
+include(Catch)
+add_executable(core_tests catch_main.cpp URI_tests.cpp)
+target_link_libraries(core_tests PUBLIC project_warnings project_options CONAN_PKG::catch2 core)
+# automatically discover tests that are defined in catch based test files you can modify the unittests. Set TEST_PREFIX to whatever you want, or use different for different binaries
+# catch_discover_tests(core_tests TEST_PREFIX  "unittests." REPORTER xml OUTPUT_DIR . OUTPUT_PREFIX "unittests." OUTPUT_SUFFIX .xml)
+catch_discover_tests(core_tests)

--- a/src/core/test/CMakeLists.txt
+++ b/src/core/test/CMakeLists.txt
@@ -1,6 +1,6 @@
 include(CTest)
 include(Catch)
-add_executable(core_tests catch_main.cpp URI_tests.cpp)
+add_executable(core_tests catch_main.cpp URI_tests.cpp MIME_tests.cpp)
 target_link_libraries(core_tests PUBLIC project_warnings project_options CONAN_PKG::catch2 core)
 # automatically discover tests that are defined in catch based test files you can modify the unittests. Set TEST_PREFIX to whatever you want, or use different for different binaries
 # catch_discover_tests(core_tests TEST_PREFIX  "unittests." REPORTER xml OUTPUT_DIR . OUTPUT_PREFIX "unittests." OUTPUT_SUFFIX .xml)

--- a/src/core/test/MIME_tests.cpp
+++ b/src/core/test/MIME_tests.cpp
@@ -1,0 +1,40 @@
+#include <Debug.hpp>
+#include <MIME.hpp>
+#include <catch2/catch.hpp>
+#include <iostream>
+#include <string_view>
+#include <sstream>
+
+TEST_CASE("basic access", "[MIME]") {
+    using namespace opencmw;
+    opencmw::debug::resetStats();
+    opencmw::debug::Timer timer("MIME - basic constructor", 40);
+
+    // simple tests
+    REQUIRE(MIME::getType(MIME::TEXT.typeName()) == MIME::TEXT);
+    REQUIRE(MIME::getTypeByFileName("readme.txt") == MIME::TEXT);
+    REQUIRE(MIME::getTypeByFileName("README.TXT") == MIME::TEXT);
+
+    for (auto type : MIME::ALL) {
+        REQUIRE_MESSAGE(MIME::getType(type.typeName()) == type, fmt::format("error for type '{}'", type.typeName()));
+        for (auto fileExt : type.fileExtensions()) {
+            REQUIRE_MESSAGE(MIME::getTypeByFileName(fmt::format("FileName{}", fileExt)) == type, fmt::format("error for type '{}' and ext '{}'", type.typeName(), fileExt));
+        }
+
+        // test print handler
+        std::ostringstream dummyStream;
+        auto resetStream = [&dummyStream](){ dummyStream.str(""); dummyStream.clear(); REQUIRE(dummyStream.str().size() == 0);};
+        dummyStream << fmt::format("MIME::MimeType fmt::print: '{}'\n", type);
+        REQUIRE(dummyStream.str().size() != 0);
+        resetStream();
+        dummyStream << "std::cout MIME::MimeType print: " << type << std::endl;
+        REQUIRE(dummyStream.str().size() != 0);
+        resetStream();
+    }
+
+    // test error cases
+    REQUIRE(MIME::getType("") == MIME::UNKNOWN);
+    REQUIRE(MIME::getType("unknown/MIME_TYPE") == MIME::UNKNOWN);
+    REQUIRE(MIME::getTypeByFileName("") == MIME::UNKNOWN);
+    REQUIRE(MIME::getTypeByFileName("FileName.unknown") == MIME::UNKNOWN);
+}

--- a/src/core/test/MIME_tests.cpp
+++ b/src/core/test/MIME_tests.cpp
@@ -2,8 +2,8 @@
 #include <MIME.hpp>
 #include <catch2/catch.hpp>
 #include <iostream>
-#include <string_view>
 #include <sstream>
+#include <string_view>
 
 TEST_CASE("basic access", "[MIME]") {
     using namespace opencmw;
@@ -23,7 +23,7 @@ TEST_CASE("basic access", "[MIME]") {
 
         // test print handler
         std::ostringstream dummyStream;
-        auto resetStream = [&dummyStream](){ dummyStream.str(""); dummyStream.clear(); REQUIRE(dummyStream.str().size() == 0);};
+        auto               resetStream = [&dummyStream]() { dummyStream.str(""); dummyStream.clear(); REQUIRE(dummyStream.str().size() == 0); };
         dummyStream << fmt::format("MIME::MimeType fmt::print: '{}'\n", type);
         REQUIRE(dummyStream.str().size() != 0);
         resetStream();

--- a/src/core/test/MIME_tests.cpp
+++ b/src/core/test/MIME_tests.cpp
@@ -12,6 +12,8 @@ TEST_CASE("basic access", "[MIME]") {
 
     // simple tests
     REQUIRE(MIME::getType(MIME::TEXT.typeName()) == MIME::TEXT);
+    REQUIRE(MIME::getType("text/plain") == MIME::TEXT);
+    REQUIRE(MIME::getType("text/PLAIN") == MIME::TEXT); // checks upper/lower case insensitivity
     REQUIRE(MIME::getTypeByFileName("readme.txt") == MIME::TEXT);
     REQUIRE(MIME::getTypeByFileName("README.TXT") == MIME::TEXT);
 

--- a/src/core/test/URI_tests.cpp
+++ b/src/core/test/URI_tests.cpp
@@ -1,0 +1,176 @@
+#pragma clang diagnostic push
+#include <Debug.hpp>
+#include <URI.hpp>
+#include <catch2/catch.hpp>
+#include <iostream>
+#include <string_view>
+
+opencmw::URI<> getUri() {
+    return opencmw::URI<>(std::string{ "mdp://User:notSoSecret@localhost.com:20/path/file.ext?queryString#cFrag" });
+}
+
+TEST_CASE("basic constructor", "[URI]") {
+    opencmw::debug::resetStats();
+    opencmw::debug::Timer timer("URI<>() - basic constructor", 40);
+
+    constexpr auto        testURL = "http://User:notSoSecretPwd@localhost.com:20/path1/path2/path3/file.ext?k0;k1=v1;k2=v2&k3&k4=#cFrag";
+    REQUIRE_NOTHROW(opencmw::URI<>(testURL));
+    // basic tests
+    opencmw::URI test(testURL);
+
+    REQUIRE(test.scheme() == "http");
+    REQUIRE(test.authority() == "User:notSoSecretPwd@localhost.com:20");
+    REQUIRE(test.user() == "User");
+    REQUIRE(test.password() == "notSoSecretPwd");
+    REQUIRE(test.hostName() == "localhost.com");
+    REQUIRE(test.port() == 20);
+    REQUIRE(test.path() == "/path1/path2/path3/file.ext");
+    REQUIRE(test.queryParam() == "k0;k1=v1;k2=v2&k3&k4=");
+    REQUIRE(test.fragment() == "cFrag");
+    // test parameter map interface
+    REQUIRE_NOTHROW(test.queryParamMap());
+    auto parameterMap = test.queryParamMap();
+    REQUIRE(parameterMap["k0"] == std::nullopt);
+    REQUIRE(parameterMap["k1"] == "v1");
+    REQUIRE(parameterMap["k2"] == "v2");
+    REQUIRE(parameterMap["k3"] == std::nullopt);
+    REQUIRE(parameterMap["k4"] == std::nullopt);
+
+    REQUIRE(getUri().authority().value() == "User:notSoSecret@localhost.com:20");
+}
+
+static const std::array<std::string, 18> validURIs{
+    "http://User:notSoSecretPwd@localhost.com:20/path1/path2/path3/file.ext?k0&k1=v1;k2=v2&k3#cFrag",
+    "mdp://user@www.fair-acc.io/service/path/resource.format?queryString#frag",
+    "mdp://www.fair-acc.io/service/path/resource.format",
+    "http://www.fair-acc.io:8080/service/path/resource.format?queryString#frag",
+    "https://www.fair-acc.io:8080/service/path/resource.format?queryString#frag",
+    "mdp://www.fair-acc.io:8080/service/path/resource.format?queryString#frag",
+    "rda3://www.fair-acc.io/service/path/resource.format?queryString#fragRda3",
+    "mdp://www.fair-acc.io/service/path/resource.format?queryString#frag",
+    "//www.fair-acc.io/service/path/resource.format?queryString#frag",
+    "mdp://user@www.fair-acc.io/service/path/resource.format?queryString",
+    "mdp://user@www.fair-acc.io/service/path/#onlyFrag",
+    "mdp://user@www.fair-acc.io#frag",
+    "mdp://www.fair-acc.io?query",
+    "mdp://www.fair-acc.io?query#frag",
+    "mdp://user:pwd@www.fair-acc.io/service/path/resource.format?format=mp4&height=360;a=2#20",
+    "mdp://www.fair-acc.io",
+    "?queryOnly",
+    "#fagmentOnly",
+};
+
+TEST_CASE("builder-parser identity", "[URI]") {
+    opencmw::debug::resetStats();
+    opencmw::debug::Timer timer("URI<>() - builder-parser identity", 40);
+
+    for (auto uri : validURIs) {
+        REQUIRE_NOTHROW(opencmw::URI<>(uri));
+
+        // check identity
+        const auto src = opencmw::URI<>(validURIs[0]);
+        const auto dst = opencmw::URI<>::factory(src).build();
+        REQUIRE(src == opencmw::URI<>(dst));
+    }
+}
+
+TEST_CASE("factory-builder API", "[URI]") {
+    using namespace opencmw;
+    opencmw::debug::resetStats();
+    opencmw::debug::Timer timer("URI<>() - factory-builder API", 40);
+
+    REQUIRE(URI<>::factory().build() == "");
+    REQUIRE(URI<>::factory().setScheme("mdp").setAuthority("authority").build() == "mdp://authority");
+    REQUIRE(URI<>::factory().setScheme("mdp").setAuthority("authority").setPath("path").build() == "mdp://authority/path");
+    REQUIRE(URI<>::factory().setScheme("file").setPath("path").build() == "file:path");
+    REQUIRE(URI<>::factory().setScheme("mdp").setHostName("localhost").setPort(8080).setPath("path").build() == "mdp://localhost:8080/path");
+    REQUIRE(URI<>::factory().setScheme("mdp").setHostName("localhost").setPort(8080).setPath("path").setQueryParam("key=value").setFragment("fragment").build() == "mdp://localhost:8080/path?key=value#fragment");
+    REQUIRE(URI<>::factory().setScheme("mdp").setHostName("localhost").setPort(8080).setPath("path").setFragment("fragment").build() == "mdp://localhost:8080/path#fragment");
+    REQUIRE(URI<>::factory().setScheme("mdp").setUser("user").setHostName("localhost").setPort(8080).setPath("path").setQueryParam("key=value").setFragment("fragment").build() == "mdp://user@localhost:8080/path?key=value#fragment");
+    REQUIRE(URI<>::factory().setScheme("mdp").setUser("user").setPassword("pwd").setHostName("localhost").setPort(8080).setPath("path").setQueryParam("key=value").setFragment("fragment").build() == "mdp://user:pwd@localhost:8080/path?key=value#fragment");
+    REQUIRE(URI<>::factory().setScheme("mdp").setPassword("pwd").setHostName("localhost").setPort(8080).setPath("path").setQueryParam("key=value").setFragment("fragment").build() == "mdp://localhost:8080/path?key=value#fragment");
+    REQUIRE(URI<>::factory().setQueryParam("queryOnly").build() == "?queryOnly");
+    REQUIRE(URI<>::factory().setFragment("fragmentOnly").build() == "#fragmentOnly");
+
+    // parameter handling
+    REQUIRE(URI<>::factory(opencmw::URI<>(validURIs[12])).setQueryParam("").addQueryParameter("keyOnly").addQueryParameter("key", "value").build() == "mdp://www.fair-acc.io?key=value&keyOnly");
+    REQUIRE(URI<>::factory(opencmw::URI<>(validURIs[12])).addQueryParameter("keyOnly").addQueryParameter("key", "value").build() == "mdp://www.fair-acc.io?query&key=value&keyOnly");
+}
+
+TEST_CASE("helper methods", "[URI]") {
+    using namespace opencmw;
+    opencmw::debug::resetStats();
+    opencmw::debug::Timer timer("URI<>() - helper methods", 40);
+    constexpr auto        validURICharacters = std::string_view("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~:/?#[]@!$&'()*+,;=");
+
+    for (auto c : validURICharacters) {
+        // implicitly tests URI<>::isUnreserved(c) for whole URI
+        REQUIRE_NOTHROW_MESSAGE(URI<STRICT>(fmt::format("a{}", c)), fmt::format("test character in whole URI: '{}'", c));
+    }
+    for (char c = 0; c < 127; c++) {
+        if (validURICharacters.find(c, 0) != std::string_view::npos) {
+            continue;
+        }
+        std::string test("abc4");
+        test[3] = c;
+        // implicitly tests URI<>::isUnreserved(c)/invalid characters for whole URI
+        REQUIRE_THROWS_AS_MESSAGE(URI<STRICT>(test), std::ios_base::failure, fmt::format("test character in URL: '{:c}'", c));
+    }
+
+    for (auto c : std::string("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789")) {
+        // implicitly tests URI<>::isUnreserved(c) for scheme
+        REQUIRE_NOTHROW_MESSAGE(URI<STRICT>(fmt::format("aa{}:", c)), fmt::format("test character in scheme: '{}'", c));
+    }
+    for (auto c : std::string("-._~/?#[]@!$&'()*+,;=")) { // N.B. special case for delimiter ':' -- "::" failure case not covered
+        // implicitly tests URI<>::isUnreserved(c)/invalid characters  for scheme
+        REQUIRE_THROWS_AS_MESSAGE(URI<STRICT>(fmt::format("aa{}:", c)), std::ios_base::failure, fmt::format("test character in scheme: '{}'", c));
+    }
+
+    for (auto c : std::string("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._:")) {
+        // implicitly tests URI<>::isUnreserved(c) for authority
+        REQUIRE_NOTHROW_MESSAGE(URI<STRICT>(fmt::format("mdp://{}", c)), fmt::format("test character in authority: '{}'", c));
+    }
+    for (auto c : std::string("~[]!$&'()*+,;=")) { // N.B. special case for delimiter '/' -- "///" failure case not covered
+        // implicitly tests URI<>::isUnreserved(c)/invalid characters for authority
+        REQUIRE_THROWS_AS_MESSAGE(URI<STRICT>(fmt::format("mdp://host{}", c)), std::ios_base::failure, fmt::format("test character in authority: '{}'", c));
+    }
+    for (auto c : std::string("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._/")) {
+        // implicitly tests URI<>::isUnreserved(c) for authority
+        REQUIRE_NOTHROW_MESSAGE(URI<STRICT>(fmt::format("mdp://auth/a{}", c)), fmt::format("test character in path: '{}'", c));
+    }
+    for (auto c : std::string("~[]!$&'()*+,;=")) {
+        // implicitly tests URI<>::isUnreserved(c)/invalid characters for authority
+        REQUIRE_THROWS_AS_MESSAGE(URI<STRICT>(fmt::format("mdp://auth/a{}", c)), std::ios_base::failure, fmt::format("test character in path: '{}'", c));
+    }
+
+    REQUIRE(URI<>::encode("ASCIIString") == "ASCIIString");
+    REQUIRE(URI<>::encode("Weird\"String\"with%,{}aa+") == "Weird%22String%22with%25%2C%7B%7Daa%2B");
+    REQUIRE(URI<>::decode(opencmw::URI<>::encode("Weird\"String\"with%,{}")) == "Weird\"String\"with%,{}");
+
+    for (char c = -128; c < 127; c++) {
+        std::string test("abc4");
+        test[3] = c;
+        REQUIRE_MESSAGE(URI<>::decode(opencmw::URI<>::encode(test)) == test, std::string("failed for: '") + test + "'");
+    }
+
+    // print handler
+    std::ostringstream dummyStream;
+    auto resetStream = [&dummyStream](){ dummyStream.str(""); dummyStream.clear(); REQUIRE(dummyStream.str().size() == 0);};
+    dummyStream << fmt::format("URI fmt::print: '{}'\n", URI<>("mdp://auth/path"));
+    REQUIRE(dummyStream.str().size() != 0);
+    resetStream();
+    dummyStream << "std::cout URI print: " << URI<>("mdp://auth/path") << std::endl;
+    REQUIRE(dummyStream.str().size() != 0);
+    resetStream();
+
+    // optional handler
+    std::optional<std::string> optional("test");
+    dummyStream << fmt::format("test std::optional fmt::print: '{}'\n", optional);
+    REQUIRE(dummyStream.str().size() != 0);
+    resetStream();
+    dummyStream << "std::cout std::optional print: " << optional << std::endl;
+    REQUIRE(dummyStream.str().size() != 0);
+    resetStream();
+}
+
+#pragma clang diagnostic pop

--- a/src/core/test/URI_tests.cpp
+++ b/src/core/test/URI_tests.cpp
@@ -155,7 +155,7 @@ TEST_CASE("helper methods", "[URI]") {
 
     // print handler
     std::ostringstream dummyStream;
-    auto resetStream = [&dummyStream](){ dummyStream.str(""); dummyStream.clear(); REQUIRE(dummyStream.str().size() == 0);};
+    auto               resetStream = [&dummyStream]() { dummyStream.str(""); dummyStream.clear(); REQUIRE(dummyStream.str().size() == 0); };
     dummyStream << fmt::format("URI fmt::print: '{}'\n", URI<>("mdp://auth/path"));
     REQUIRE(dummyStream.str().size() != 0);
     resetStream();

--- a/src/core/test/URI_tests.cpp
+++ b/src/core/test/URI_tests.cpp
@@ -69,7 +69,7 @@ TEST_CASE("builder-parser identity", "[URI]") {
 
         // check identity
         const auto src = opencmw::URI<>(validURIs[0]);
-        const auto dst = opencmw::URI<>::factory(src).build();
+        const auto dst = opencmw::URI<>::factory(src).toString();
         REQUIRE(src == opencmw::URI<>(dst));
     }
 }
@@ -79,22 +79,24 @@ TEST_CASE("factory-builder API", "[URI]") {
     opencmw::debug::resetStats();
     opencmw::debug::Timer timer("URI<>() - factory-builder API", 40);
 
-    REQUIRE(URI<>::factory().build() == "");
-    REQUIRE(URI<>::factory().setScheme("mdp").setAuthority("authority").build() == "mdp://authority");
-    REQUIRE(URI<>::factory().setScheme("mdp").setAuthority("authority").setPath("path").build() == "mdp://authority/path");
-    REQUIRE(URI<>::factory().setScheme("file").setPath("path").build() == "file:path");
-    REQUIRE(URI<>::factory().setScheme("mdp").setHostName("localhost").setPort(8080).setPath("path").build() == "mdp://localhost:8080/path");
-    REQUIRE(URI<>::factory().setScheme("mdp").setHostName("localhost").setPort(8080).setPath("path").setQueryParam("key=value").setFragment("fragment").build() == "mdp://localhost:8080/path?key=value#fragment");
-    REQUIRE(URI<>::factory().setScheme("mdp").setHostName("localhost").setPort(8080).setPath("path").setFragment("fragment").build() == "mdp://localhost:8080/path#fragment");
-    REQUIRE(URI<>::factory().setScheme("mdp").setUser("user").setHostName("localhost").setPort(8080).setPath("path").setQueryParam("key=value").setFragment("fragment").build() == "mdp://user@localhost:8080/path?key=value#fragment");
-    REQUIRE(URI<>::factory().setScheme("mdp").setUser("user").setPassword("pwd").setHostName("localhost").setPort(8080).setPath("path").setQueryParam("key=value").setFragment("fragment").build() == "mdp://user:pwd@localhost:8080/path?key=value#fragment");
-    REQUIRE(URI<>::factory().setScheme("mdp").setPassword("pwd").setHostName("localhost").setPort(8080).setPath("path").setQueryParam("key=value").setFragment("fragment").build() == "mdp://localhost:8080/path?key=value#fragment");
-    REQUIRE(URI<>::factory().setQueryParam("queryOnly").build() == "?queryOnly");
-    REQUIRE(URI<>::factory().setFragment("fragmentOnly").build() == "#fragmentOnly");
+    REQUIRE(URI<>::factory().toString() == "");
+    REQUIRE(URI<>::factory().scheme("mdp").authority("authority").toString() == "mdp://authority");
+    REQUIRE(URI<>::factory().scheme("mdp").authority("authority").path("path").toString() == "mdp://authority/path");
+    REQUIRE(URI<>::factory().scheme("file").path("path").toString() == "file:path");
+    REQUIRE(URI<>::factory().scheme("mdp").hostName("localhost").port(8080).path("path").toString() == "mdp://localhost:8080/path");
+    REQUIRE(URI<>::factory().scheme("mdp").hostName("localhost").port(8080).path("path").queryParam("key=value").fragment("fragment").toString() == "mdp://localhost:8080/path?key=value#fragment");
+    REQUIRE(URI<>::factory().scheme("mdp").hostName("localhost").port(8080).path("path").fragment("fragment").toString() == "mdp://localhost:8080/path#fragment");
+    REQUIRE(URI<>::factory().scheme("mdp").user("user").hostName("localhost").port(8080).path("path").queryParam("key=value").fragment("fragment").toString() == "mdp://user@localhost:8080/path?key=value#fragment");
+    REQUIRE(URI<>::factory().scheme("mdp").user("user").password("pwd").hostName("localhost").port(8080).path("path").queryParam("key=value").fragment("fragment").toString() == "mdp://user:pwd@localhost:8080/path?key=value#fragment");
+    REQUIRE(URI<>::factory().scheme("mdp").password("pwd").hostName("localhost").port(8080).path("path").queryParam("key=value").fragment("fragment").toString() == "mdp://localhost:8080/path?key=value#fragment");
+    REQUIRE(URI<>::factory().queryParam("queryOnly").toString() == "?queryOnly");
+    REQUIRE(URI<>::factory().fragment("fragmentOnly").toString() == "#fragmentOnly");
+
+    REQUIRE(URI<>::factory().scheme("mdp").authority("authority").build().authority() == "authority");
 
     // parameter handling
-    REQUIRE(URI<>::factory(opencmw::URI<>(validURIs[12])).setQueryParam("").addQueryParameter("keyOnly").addQueryParameter("key", "value").build() == "mdp://www.fair-acc.io?key=value&keyOnly");
-    REQUIRE(URI<>::factory(opencmw::URI<>(validURIs[12])).addQueryParameter("keyOnly").addQueryParameter("key", "value").build() == "mdp://www.fair-acc.io?query&key=value&keyOnly");
+    REQUIRE(URI<>::factory(opencmw::URI<>(validURIs[12])).queryParam("").addQueryParameter("keyOnly").addQueryParameter("key", "value").toString() == "mdp://www.fair-acc.io?key=value&keyOnly");
+    REQUIRE(URI<>::factory(opencmw::URI<>(validURIs[12])).addQueryParameter("keyOnly").addQueryParameter("key", "value").toString() == "mdp://www.fair-acc.io?query&key=value&keyOnly");
 }
 
 TEST_CASE("helper methods", "[URI]") {

--- a/src/core/test/catch_main.cpp
+++ b/src/core/test/catch_main.cpp
@@ -1,0 +1,3 @@
+#define CATCH_CONFIG_MAIN // This tells the catch header to generate a main
+
+#include <catch2/catch.hpp>

--- a/src/majordomo/include/majordomo/Broker.hpp
+++ b/src/majordomo/include/majordomo/Broker.hpp
@@ -52,7 +52,7 @@ private:
     using Timestamp = std::chrono::time_point<Clock>;
 
     struct Client {
-        const Socket             &socket;
+        const Socket &            socket;
         const std::string         id;
         std::deque<BrokerMessage> requests;
 
@@ -63,7 +63,7 @@ private:
     };
 
     struct Worker {
-        const Socket     &socket;
+        const Socket &    socket;
         const std::string id;
         const std::string serviceName;
         Timestamp         expiry;
@@ -130,7 +130,7 @@ private:
     const Socket                  _dnsSocket;
     std::array<zmq_pollitem_t, 4> pollerItems;
 
-    Service                      &requireService(std::string serviceName, std::string serviceDescription) {
+    Service &                     requireService(std::string serviceName, std::string serviceDescription) {
         // TODO handle serviceDescription differing between workers? or is "first one wins" ok?
         auto it = _services.try_emplace(serviceName, std::move(serviceName), std::move(serviceDescription));
         return it.first->second;
@@ -286,7 +286,7 @@ private:
         const auto serviceName = std::string(message.serviceName());
         const auto serviceId   = std::string(message.sourceId());
         const auto knownWorker = _workers.contains(serviceId);
-        auto      &worker      = _workers.try_emplace(serviceId, socket, serviceId, serviceName).first->second;
+        auto &     worker      = _workers.try_emplace(serviceId, socket, serviceId, serviceName).first->second;
         worker.updateExpiry();
 
         switch (message.workerCommand()) {

--- a/src/majordomo/include/majordomo/Broker.hpp
+++ b/src/majordomo/include/majordomo/Broker.hpp
@@ -52,7 +52,7 @@ private:
     using Timestamp = std::chrono::time_point<Clock>;
 
     struct Client {
-        const Socket &            socket;
+        const Socket             &socket;
         const std::string         id;
         std::deque<BrokerMessage> requests;
 
@@ -63,7 +63,7 @@ private:
     };
 
     struct Worker {
-        const Socket &    socket;
+        const Socket     &socket;
         const std::string id;
         const std::string serviceName;
         Timestamp         expiry;
@@ -130,7 +130,7 @@ private:
     const Socket                  _dnsSocket;
     std::array<zmq_pollitem_t, 4> pollerItems;
 
-    Service &                     requireService(std::string serviceName, std::string serviceDescription) {
+    Service                      &requireService(std::string serviceName, std::string serviceDescription) {
         // TODO handle serviceDescription differing between workers? or is "first one wins" ok?
         auto it = _services.try_emplace(serviceName, std::move(serviceName), std::move(serviceDescription));
         return it.first->second;
@@ -286,7 +286,7 @@ private:
         const auto serviceName = std::string(message.serviceName());
         const auto serviceId   = std::string(message.sourceId());
         const auto knownWorker = _workers.contains(serviceId);
-        auto &     worker      = _workers.try_emplace(serviceId, socket, serviceId, serviceName).first->second;
+        auto      &worker      = _workers.try_emplace(serviceId, socket, serviceId, serviceName).first->second;
         worker.updateExpiry();
 
         switch (message.workerCommand()) {
@@ -434,7 +434,7 @@ public:
     Broker &operator=(const Broker &) = delete;
 
     enum class BindOption {
-        DetectFromURI, ///< detect from URI which socket is meant (@see bind)
+        DetectFromURI, ///< detect from uri which socket is meant (@see bind)
         Router,        ///< Always bind ROUTER socket
         Pub            ///< Always bind PUB socket
     };
@@ -443,7 +443,7 @@ public:
      * Bind broker to endpoint, can call this multiple times. We use a single
      * socket for both clients and workers.
      *
-     * @param endpoint the URI-based 'scheme://ip:port' endpoint definition the server should listen to
+     * @param endpoint the uri-based 'scheme://ip:port' endpoint definition the server should listen to
      * The protocol definition
      *  - 'mdp://' corresponds to a SocketType.ROUTER socket
      *  - 'mds://' corresponds to a SocketType.XPUB socket

--- a/src/serialiser/CMakeLists.txt
+++ b/src/serialiser/CMakeLists.txt
@@ -1,6 +1,3 @@
-# ensure dependencies are present
-#include_directories(${refl-cpp_SOURCE_DIR})
-
 # setup header only library
 add_library(serialiser INTERFACE)
 target_include_directories(serialiser INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include> $<INSTALL_INTERFACE:${CMAKE_INSTALL_PREFIX}/include/>)

--- a/src/utils/include/Debug.hpp
+++ b/src/utils/include/Debug.hpp
@@ -10,6 +10,18 @@
         REQUIRE(cond); \
     } while ((void) 0, 0)
 
+#define REQUIRE_NOTHROW_MESSAGE(cond, msg) \
+    do { \
+        INFO(msg); \
+        REQUIRE_NOTHROW(cond); \
+    } while ((void) 0, 0)
+
+#define REQUIRE_THROWS_AS_MESSAGE(cond, exception, msg) \
+    do { \
+        INFO(msg); \
+        REQUIRE_THROWS_AS(cond, exception); \
+    } while ((void) 0, 0)
+
 // #define OPENCMW_INSTRUMENT_ALLOC 1 //NOLINT -- used as a global macro to enable alloc/free profiling
 namespace opencmw::debug {
 static std::size_t alloc{ 0 };   // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
@@ -31,7 +43,7 @@ static void        resetStats() {
 #pragma ide diagnostic   ignored "UnusedLocalVariable"
 class Timer {
 private:
-    const char *      _message;
+    const char       *_message;
     const int         _alignMsg;
     const int         _alignClock;
     const int         _alignTime;
@@ -102,7 +114,7 @@ public:
 #pragma ide diagnostic   ignored "cppcoreguidelines-owning-memory"
 #pragma ide diagnostic   ignored "cppcoreguidelines-macro-usage"
 #pragma ide diagnostic   ignored "misc-definitions-in-headers"
-void *                   opencmw_malloc(size_t size) {
+void                    *opencmw_malloc(size_t size) {
     opencmw::debug::alloc += 1;
     return std::malloc(size);
 }
@@ -122,10 +134,10 @@ void opencmw_free(void *ptr) {
 #define free(X) opencmw_free(X)
 #define realloc(X, Y) opencmw_realloc(X, Y)
 
-void *                   operator new(std::size_t size) { return malloc(size); }
+void                    *operator new(std::size_t size) { return malloc(size); }
 void                     operator delete(void *ptr) noexcept { free(ptr); }
 void                     operator delete(void *ptr, std::size_t /*unused*/) noexcept { free(ptr); }
 #pragma clang diagnostic pop
-#endif //OPENCMW_INSTRUMENT_ALLOC
+#endif // OPENCMW_INSTRUMENT_ALLOC
 
-#endif //OPENCMW_DEBUG_H
+#endif // OPENCMW_DEBUG_H

--- a/src/utils/include/Debug.hpp
+++ b/src/utils/include/Debug.hpp
@@ -43,7 +43,7 @@ static void        resetStats() {
 #pragma ide diagnostic   ignored "UnusedLocalVariable"
 class Timer {
 private:
-    const char       *_message;
+    const char *      _message;
     const int         _alignMsg;
     const int         _alignClock;
     const int         _alignTime;
@@ -114,7 +114,7 @@ public:
 #pragma ide diagnostic   ignored "cppcoreguidelines-owning-memory"
 #pragma ide diagnostic   ignored "cppcoreguidelines-macro-usage"
 #pragma ide diagnostic   ignored "misc-definitions-in-headers"
-void                    *opencmw_malloc(size_t size) {
+void *                   opencmw_malloc(size_t size) {
     opencmw::debug::alloc += 1;
     return std::malloc(size);
 }
@@ -134,7 +134,7 @@ void opencmw_free(void *ptr) {
 #define free(X) opencmw_free(X)
 #define realloc(X, Y) opencmw_realloc(X, Y)
 
-void                    *operator new(std::size_t size) { return malloc(size); }
+void *                   operator new(std::size_t size) { return malloc(size); }
 void                     operator delete(void *ptr) noexcept { free(ptr); }
 void                     operator delete(void *ptr, std::size_t /*unused*/) noexcept { free(ptr); }
 #pragma clang diagnostic pop


### PR DESCRIPTION
for review: 
* added URI custom parsing code according to RFC-3986 (for comparison: [compile-time regex implementation](https://compiler-explorer.com/z/a7W3eosYM) and regex [test](regexr.com/69hv8))
* added most common MIME definitions according to RFC6838 and RFC4855

sticked to the initial custom implementations, to note:
* investigate `constexpr` use for MIME::MimeType (<-> syntax for `std::array` initialisation in constructor)
* use of [CTRE](https://github.com/hanickadot/compile-time-regular-expressions) library -> nice and highly-performant regex library but usage in URI parser alone does not merit the additional external library dependency (if necessary, the shorter version is in the compiler-explorer sample linked above)


open for comments