### PR TITLE
Enable coverage explicitly

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,7 +63,7 @@ include(cmake/ReflCpp.cmake) # todo: switch to obtaining reflcpp from conan
 if(ENABLE_TESTING)
   enable_testing()
   message("Building Tests.")
-  if (ENABLE_COVERAGE)
+  if (ENABLE_COVERAGE AND (CMAKE_BUILD_TYPE STREQUAL "Debug" OR GENERATOR_IS_MULTI_CONFIG))
     if(UNIX AND NOT APPLE) # Linux
       message("Coverage reporting enabled")
       include(cmake/CodeCoverage.cmake) # https://github.com/bilke/cmake-modules/blob/master/CodeCoverage.cmake (License: BSL-1.0)
@@ -74,13 +74,13 @@ if(ENABLE_TESTING)
               NAME coverage
               EXECUTABLE ctest
               DEPENDENCIES serialiser_tests
-              EXCLUDE "$CMAKE_BUILD_DIR/*" "concepts/*"
+              EXCLUDE "$CMAKE_BUILD_DIR/*" "concepts/.*" ".*/test/.*"
       )
       setup_target_for_coverage_gcovr_html(
               NAME coverage_html
               EXECUTABLE ctest
               DEPENDENCIES serialiser_tests
-              EXCLUDE "$CMAKE_BUILD_DIR/*" "concepts/*"
+              EXCLUDE "$CMAKE_BUILD_DIR/*" "concepts/.*" ".*/test/.*"
       )
     else()
       message(WARNING "Coverage is only supported on linux")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,11 @@ enable_doxygen()
 include(cmake/StaticAnalyzers.cmake)
 
 option(ENABLE_TESTING "Enable Test Builds" ON)
-option(ENABLE_COVERAGE "Enable Coverage for Test Builds" ON)
+if (CMAKE_BUILD_TYPE STREQUAL "Debug" OR GENERATOR_IS_MULTI_CONFIG)
+  option(ENABLE_COVERAGE "Enable Coverage" ON)
+else()
+  option(ENABLE_COVERAGE "Enable Coverage" OFF)
+endif()
 option(ENABLE_CONCEPTS "Enable Concepts Builds" ON)
 
 # Very basic PCH example
@@ -63,7 +67,7 @@ include(cmake/ReflCpp.cmake) # todo: switch to obtaining reflcpp from conan
 if(ENABLE_TESTING)
   enable_testing()
   message("Building Tests.")
-  if (ENABLE_COVERAGE AND (CMAKE_BUILD_TYPE STREQUAL "Debug" OR GENERATOR_IS_MULTI_CONFIG))
+  if (ENABLE_COVERAGE)
     if(UNIX AND NOT APPLE) # Linux
       message("Coverage reporting enabled")
       include(cmake/CodeCoverage.cmake) # https://github.com/bilke/cmake-modules/blob/master/CodeCoverage.cmake (License: BSL-1.0)


### PR DESCRIPTION
Make ENABLE_COVERAGE default to OFF and actively enable it in the github action's debug/coverage build.
Enabling coverage for non debug builds does not lead to useful results and for the debugging usecase coverage is also not required.

Thanks to @frankosterfeld for the suggestion.

