### PR TITLE
Update codecov-action to v2

### DIFF
--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -103,7 +103,7 @@ jobs:
       # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
       run: cmake --build . --config ${{ matrix.cmake-build-type }} --target coverage
 
-    - uses: codecov/codecov-action@v1
+    - uses: codecov/codecov-action@v2
       if: matrix.configurations.os == env.REFERENCE_OS && matrix.cmake-build-type == 'Debug'
       with:
         files: ${{runner.workspace}}/build/coverage.xml


### PR DESCRIPTION
v1 uses the deprecated bash uploader and is not maintained anymore. This also might fix some spurious failed coverage uploads we have [observed](https://github.com/fair-acc/opencmw-cpp/pull/83#issuecomment-994824884).

All other github actions are up to date.