### PR TITLE
thread affinity and priority utils

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -1,7 +1,7 @@
 # setup header only library
 add_library(core INTERFACE)
 target_include_directories(core INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include> $<INSTALL_INTERFACE:${CMAKE_INSTALL_PREFIX}/include/>)
-target_link_libraries(core INTERFACE CONAN_PKG::mp-units refl-cpp::refl-cpp utils)
+target_link_libraries(core INTERFACE CONAN_PKG::mp-units refl-cpp::refl-cpp utils pthread)
 set_target_properties(core PROPERTIES PUBLIC_HEADER "include/URI.hpp;include/MIME.hpp")
 
 install(

--- a/src/core/include/ThreadAffinity.hpp
+++ b/src/core/include/ThreadAffinity.hpp
@@ -96,7 +96,7 @@ std::string getProcessName(const int pid = detail::getPid()) {
         return fileContent;
     }
 #endif
-    return "unknown process name";
+    return "unknown_process";
 } // namespace detail
 
 std::string getThreadName(thread_type auto &...thread) {

--- a/src/core/include/ThreadAffinity.hpp
+++ b/src/core/include/ThreadAffinity.hpp
@@ -1,0 +1,330 @@
+#ifndef OPENCMW_CPP_THREADAFFINITY_HPP
+#define OPENCMW_CPP_THREADAFFINITY_HPP
+
+#include <algorithm>
+#include <fmt/format.h>
+#include <fmt/ranges.h>
+#include <fstream>
+#include <iostream>
+#include <mutex>
+#include <optional>
+#include <sstream>
+#include <system_error>
+#include <thread>
+#include <vector>
+
+#if !defined(_WIN32) && (defined(__unix__) || defined(__unix) || (defined(__APPLE__) && defined(__MACH__))) // UNIX-style OS
+#include <unistd.h>
+#ifdef _POSIX_VERSION // POSIX compliant
+#include <pthread.h>
+#include <sched.h>
+#endif
+#endif
+
+namespace opencmw::thread {
+
+constexpr size_t THREAD_MAX_NAME_LENGTH = 16;
+constexpr int    THREAD_UNINITIALISED   = 1;
+constexpr int    THREAD_ERROR_UNKNOWN   = 2;
+constexpr int    THREAD_VALUE_RANGE     = 3;
+constexpr int    THREAD_ERANGE          = 34;
+
+class thread_exception : public std::error_category {
+public:
+    constexpr thread_exception()
+        : std::error_category(){};
+
+    const char *name() const noexcept { return "thread_exception"; };
+    std::string message(int errorCode) const {
+        switch (errorCode) {
+        case THREAD_UNINITIALISED:
+            return "thread uninitialised or user does not have the appropriate rights (ie. CAP_SYS_NICE capability)";
+        case THREAD_ERROR_UNKNOWN:
+            return "thread error code 2";
+        case THREAD_ERANGE:
+            return fmt::format("length of the string specified pointed to by name exceeds the allowed limit THREAD_MAX_NAME_LENGTH = '{}'", THREAD_MAX_NAME_LENGTH);
+        case THREAD_VALUE_RANGE:
+            return fmt::format("priority out of valid range for scheduling policy", THREAD_MAX_NAME_LENGTH);
+        default:
+            return fmt::format("unknown threading error code {}", errorCode);
+        }
+    };
+};
+
+template<class type>
+concept thread_type = std::is_same<type, std::thread>::value || std::is_same<type, std::jthread>::value;
+
+namespace detail{
+#ifdef _POSIX_VERSION
+    template<typename Tp, typename... Us>
+    constexpr decltype(auto) firstElement(Tp && t, Us &&...) noexcept {
+            return std::forward<Tp>(t);
+}
+
+inline constexpr pthread_t getPosixHandler(thread_type auto &...t) noexcept {
+    if constexpr (sizeof...(t) > 0) {
+        return firstElement(t...).native_handle();
+    } else {
+        return pthread_self();
+    }
+}
+
+std::string getThreadName(const pthread_t &handle) {
+    if (handle == 0U) {
+        return "uninitialised thread";
+    }
+    char threadName[THREAD_MAX_NAME_LENGTH];
+    if (int rc = pthread_getname_np(handle, threadName, THREAD_MAX_NAME_LENGTH) != 0) {
+        throw std::system_error(rc, thread_exception(), fmt::format("getThreadName(thread_type)"));
+    }
+    return std::string{ threadName, std::min(strlen(threadName), THREAD_MAX_NAME_LENGTH) };
+}
+
+int getPid() { return getpid(); }
+#else
+    int detail::getPid(){ return 0;
+}
+#endif
+} // namespace detail
+
+std::string getProcessName(const int pid = detail::getPid()) {
+#ifdef _POSIX_VERSION
+    std::ifstream in(fmt::format("/proc/{}/comm", pid), std::ios::in);
+    if (in.is_open()) {
+        std::string fileContent;
+        std::getline(in, fileContent, '\n');
+        return fileContent;
+    }
+#endif
+    return "unknown process name";
+} // namespace detail
+
+std::string getThreadName(thread_type auto &...thread) {
+#ifdef _POSIX_VERSION
+    const pthread_t handle = detail::getPosixHandler(thread...);
+    if (handle == 0U) {
+        throw std::system_error(THREAD_UNINITIALISED, thread_exception(), fmt::format("getThreadName(thread_type)"));
+    }
+    return detail::getThreadName(handle);
+#else
+    return "unknown thread name";
+#endif
+}
+
+void setProcessName(const std::string_view &processName, int pid = detail::getPid()) {
+#ifdef _POSIX_VERSION
+    std::ofstream out(fmt::format("/proc/{}/comm", pid), std::ios::out);
+    if (!out.is_open()) {
+        throw std::system_error(THREAD_UNINITIALISED, thread_exception(), fmt::format("setProcessName({},{})", processName, pid));
+    }
+    out << std::string{ processName.cbegin(), std::min(15LU, processName.size()) };
+    out.close();
+#endif
+}
+
+void setThreadName(const std::string_view &threadName, thread_type auto &...thread) {
+#ifdef _POSIX_VERSION
+    const pthread_t handle = detail::getPosixHandler(thread...);
+    if (handle == 0U) {
+        throw std::system_error(THREAD_UNINITIALISED, thread_exception(), fmt::format("setThreadName({}, thread_type)", threadName, detail::getThreadName(handle)));
+    }
+    if (int rc = pthread_setname_np(handle, threadName.data()) < 0) {
+        throw std::system_error(rc, thread_exception(), fmt::format("setThreadName({},{}) - error code '{}'", threadName, detail::getThreadName(handle), rc));
+    }
+#endif
+}
+
+namespace detail {
+#ifdef _POSIX_VERSION
+std::vector<bool> getAffinityMask(const cpu_set_t &cpuSet) {
+    std::vector<bool> bitMask(std::min(sizeof(cpu_set_t), static_cast<size_t>(std::thread::hardware_concurrency())));
+    for (size_t i = 0; i < bitMask.size(); i++) {
+        bitMask[i] = CPU_ISSET(i, &cpuSet);
+    }
+    return bitMask;
+}
+
+template<class T>
+requires requires(T value) { std::get<0>(value); }
+constexpr cpu_set_t getAffinityMask(const T &threadMap) {
+    cpu_set_t cpuSet;
+    CPU_ZERO(&cpuSet);
+    size_t nMax = std::min(threadMap.size(), static_cast<size_t>(std::thread::hardware_concurrency()));
+    for (size_t i = 0; i < nMax; i++) {
+        if (threadMap[i]) {
+            CPU_SET(i, &cpuSet);
+        } else {
+            CPU_CLR(i, &cpuSet);
+        }
+    }
+    return cpuSet;
+}
+#endif
+} // namespace detail
+
+std::vector<bool> getThreadAffinity(thread_type auto &...thread) {
+#ifdef _POSIX_VERSION
+    const pthread_t handle = detail::getPosixHandler(thread...);
+    if (handle == 0U) {
+        throw std::system_error(THREAD_UNINITIALISED, thread_exception(), fmt::format("getThreadAffinity(thread_type)"));
+    }
+    cpu_set_t cpuSet;
+    if (int rc = pthread_getaffinity_np(handle, sizeof(cpu_set_t), &cpuSet) != 0) {
+        throw std::system_error(rc, thread_exception(), fmt::format("getThreadAffinity({})", detail::getThreadName(handle)));
+    }
+    return detail::getAffinityMask(cpuSet);
+#else
+    return std::vector<bool>(std::thread::hardware_concurrency()); // cannot set affinity for non-posix threads
+#endif
+}
+
+template<class T>
+requires requires(T value) { std::get<0>(value); }
+constexpr bool setThreadAffinity(const T &threadMap, thread_type auto &...thread) {
+#ifdef _POSIX_VERSION
+    const pthread_t handle = detail::getPosixHandler(thread...);
+    if (handle == 0U) {
+        throw std::system_error(THREAD_UNINITIALISED, thread_exception(), fmt::format("setThreadAffinity(std::vector<bool, {}> = {{{}}}, thread_type)", threadMap.size(), fmt::join(threadMap, ", ")));
+    }
+    cpu_set_t cpuSet = detail::getAffinityMask(threadMap);
+    if (int rc = pthread_setaffinity_np(handle, sizeof(cpu_set_t), &cpuSet) != 0) {
+        throw std::system_error(rc, thread_exception(), fmt::format("setThreadAffinity(std::vector<bool, {}> = {{{}}}, {})", threadMap.size(), fmt::join(threadMap, ", "), detail::getThreadName(handle)));
+    }
+    return true;
+#else
+    return false;                                                  // cannot set affinity for non-posix threads
+#endif
+}
+
+std::vector<bool> getProcessAffinity(const int pid = detail::getPid()) {
+#ifdef _POSIX_VERSION
+    if (pid <= 0) {
+        throw std::system_error(THREAD_UNINITIALISED, thread_exception(), fmt::format("getProcessAffinity({}) -- invalid pid", pid));
+    }
+    cpu_set_t cpuSet;
+    if (int rc = sched_getaffinity(pid, sizeof(cpu_set_t), &cpuSet) != 0) {
+        throw std::system_error(rc, thread_exception(), fmt::format("getProcessAffinity(std::bitset<{}> = {}, thread_type)"));
+    }
+    return detail::getAffinityMask(cpuSet);
+#else
+    return std::vector<bool>(std::thread::hardware_concurrency()); // cannot set affinity for non-posix threads
+#endif
+}
+
+template<class T>
+requires requires(T value) { std::get<0>(value); }
+constexpr bool setProcessAffinity(const T &threadMap, const int pid = detail::getPid()) {
+#ifdef _POSIX_VERSION
+    if (pid <= 0) {
+        throw std::system_error(THREAD_UNINITIALISED, thread_exception(), fmt::format("setProcessAffinity(std::vector<bool, {}> = {{{}}}, {})", threadMap.size(), fmt::join(threadMap, ", "), pid));
+    }
+    cpu_set_t cpuSet = detail::getAffinityMask(threadMap);
+    if (int rc = sched_setaffinity(pid, sizeof(cpu_set_t), &cpuSet) != 0) {
+        throw std::system_error(rc, thread_exception(), fmt::format("setProcessAffinity(std::vector<bool, {}> = {{{}}}, {})", threadMap.size(), fmt::join(threadMap, ", "), pid));
+    }
+
+    return true;
+#else
+    return false;                                                  // cannot set affinity for non-posix threads
+#endif
+}
+enum Policy {
+    OTHER       = 0,
+    FIFO        = 1,
+    ROUND_ROBIN = 2
+};
+
+struct SchedulingParameter {
+    Policy policy; // e.g. SCHED_OTHER, SCHED_RR, FSCHED_FIFO
+    int    priority;
+};
+
+namespace detail {
+#ifdef _POSIX_VERSION
+Policy getEnumPolicy(const int policy) {
+    switch (policy) {
+    case SCHED_FIFO: return FIFO;
+    case SCHED_RR: return ROUND_ROBIN;
+    case SCHED_OTHER:
+    default:
+        return OTHER;
+    }
+}
+#endif
+} // namespace detail
+
+struct SchedulingParameter getProcessSchedulingParameter(const int pid = detail::getPid()) {
+#ifdef _POSIX_VERSION
+    if (pid <= 0) {
+        throw std::system_error(THREAD_UNINITIALISED, thread_exception(), fmt::format("getProcessSchedulingParameter({}) -- invalid pid", pid));
+    }
+    struct sched_param param;
+    const int          policy = sched_getscheduler(pid);
+    if (int rc = sched_getparam(pid, &param) != 0) {
+        throw std::system_error(rc, thread_exception(), fmt::format("getProcessSchedulingParameter({}) - sched_getparam error", pid));
+    }
+    return SchedulingParameter{ .policy = detail::getEnumPolicy(policy), .priority = param.sched_priority };
+#else
+    return struct SchedulingParameter {};
+#endif
+}
+
+void setProcessSchedulingParameter(Policy scheduler, int priority, const int pid = detail::getPid()) {
+#ifdef _POSIX_VERSION
+    if (pid <= 0) {
+        throw std::system_error(THREAD_UNINITIALISED, thread_exception(), fmt::format("setProcessSchedulingParameter({}, {}, {}) -- invalid pid", scheduler, priority, pid));
+    }
+    const int minPriority = sched_get_priority_min(scheduler);
+    const int maxPriority = sched_get_priority_max(scheduler);
+    if (priority < minPriority || priority > maxPriority) {
+        throw std::system_error(THREAD_VALUE_RANGE, thread_exception(), fmt::format("setProcessSchedulingParameter({}, {}, {}) -- requested priority out-of-range [{}, {}]", scheduler, priority, pid, minPriority, maxPriority));
+    }
+    struct sched_param param {
+        .sched_priority = priority
+    };
+    if (int rc = sched_setscheduler(pid, scheduler, &param) != 0) {
+        throw std::system_error(rc, thread_exception(), fmt::format("setProcessSchedulingParameter({}, {}, {}) - sched_setscheduler return code: {}", scheduler, priority, pid, rc));
+    }
+#endif
+}
+
+struct SchedulingParameter getThreadSchedulingParameter(thread_type auto &...thread) {
+#ifdef _POSIX_VERSION
+    const pthread_t handle = detail::getPosixHandler(thread...);
+    if (handle == 0U) {
+        throw std::system_error(THREAD_UNINITIALISED, thread_exception(), fmt::format("getThreadSchedulingParameter(thread_type) -- invalid thread"));
+    }
+    struct sched_param param;
+    int                policy;
+    if (int rc = pthread_getschedparam(handle, &policy, &param) != 0) {
+        throw std::system_error(rc, thread_exception(), fmt::format("getThreadSchedulingParameter({}) - sched_getparam error", detail::getThreadName(handle)));
+    }
+    return SchedulingParameter{ .policy = detail::getEnumPolicy(policy), .priority = param.sched_priority };
+#else
+    return struct SchedulingParameter {};
+#endif
+}
+
+void setThreadSchedulingParameter(Policy scheduler, int priority, thread_type auto &...thread) {
+#ifdef _POSIX_VERSION
+    const pthread_t handle = detail::getPosixHandler(thread...);
+    if (handle == 0U) {
+        throw std::system_error(THREAD_UNINITIALISED, thread_exception(), fmt::format("setThreadSchedulingParameter({}, {}, thread_type) -- invalid thread", scheduler, priority));
+    }
+    const int minPriority = sched_get_priority_min(scheduler);
+    const int maxPriority = sched_get_priority_max(scheduler);
+    if (priority < minPriority || priority > maxPriority) {
+        throw std::system_error(THREAD_VALUE_RANGE, thread_exception(), fmt::format("setThreadSchedulingParameter({}, {}, {}) -- requested priority out-of-range [{}, {}]", scheduler, priority, detail::getThreadName(handle), minPriority, maxPriority));
+    }
+    struct sched_param param {
+        .sched_priority = priority
+    };
+    if (int rc = pthread_setschedparam(handle, scheduler, &param) != 0) {
+        throw std::system_error(rc, thread_exception(), fmt::format("setThreadSchedulingParameter({}, {}, {}) - pthread_setschedparam return code: {}", scheduler, priority, detail::getThreadName(handle), rc));
+    }
+#endif
+}
+
+} // namespace opencmw::thread
+
+#endif // OPENCMW_CPP_THREADAFFINITY_HPP

--- a/src/core/test/CMakeLists.txt
+++ b/src/core/test/CMakeLists.txt
@@ -1,8 +1,7 @@
 include(CTest)
 include(Catch)
-add_executable(core_tests catch_main.cpp URI_tests.cpp MIME_tests.cpp TimingCtx_tests.cpp)
-
-target_link_libraries(core_tests PUBLIC project_warnings project_options CONAN_PKG::catch2 core)
+add_executable(core_tests catch_main.cpp URI_tests.cpp MIME_tests.cpp TimingCtx_tests.cpp ThreadAffinity_tests.cpp)
+target_link_libraries(core_tests PUBLIC project_warnings project_options CONAN_PKG::catch2 core pthread)
 # automatically discover tests that are defined in catch based test files you can modify the unittests. Set TEST_PREFIX to whatever you want, or use different for different binaries
 # catch_discover_tests(core_tests TEST_PREFIX  "unittests." REPORTER xml OUTPUT_DIR . OUTPUT_PREFIX "unittests." OUTPUT_SUFFIX .xml)
 catch_discover_tests(core_tests)

--- a/src/core/test/ThreadAffinity_tests.cpp
+++ b/src/core/test/ThreadAffinity_tests.cpp
@@ -9,6 +9,25 @@
         REQUIRE(cond); \
     } while ((void) 0, 0)
 
+TEST_CASE("thread_exception", "[ThreadAffinity]") {
+    REQUIRE_NOTHROW(opencmw::thread::thread_exception());
+    REQUIRE(std::string("thread_exception") == opencmw::thread::thread_exception().name());
+    REQUIRE(opencmw::thread::thread_exception().message(-1) == "unknown threading error code -1");
+    REQUIRE(opencmw::thread::thread_exception().message(-2) == "unknown threading error code -2");
+    REQUIRE(!opencmw::thread::thread_exception().message(opencmw::thread::THREAD_UNINITIALISED).starts_with("unknown threading error code"));
+    REQUIRE(!opencmw::thread::thread_exception().message(opencmw::thread::THREAD_ERROR_UNKNOWN).starts_with("unknown threading error code"));
+    REQUIRE(!opencmw::thread::thread_exception().message(opencmw::thread::THREAD_VALUE_RANGE).starts_with("unknown threading error code"));
+    REQUIRE(!opencmw::thread::thread_exception().message(opencmw::thread::THREAD_ERANGE).starts_with("unknown threading error code"));
+}
+
+TEST_CASE("thread_helper", "[ThreadAffinity]") {
+    REQUIRE(opencmw::thread::detail::getEnumPolicy(SCHED_FIFO) == opencmw::thread::Policy::FIFO);
+    REQUIRE(opencmw::thread::detail::getEnumPolicy(SCHED_RR) == opencmw::thread::Policy::ROUND_ROBIN);
+    REQUIRE(opencmw::thread::detail::getEnumPolicy(SCHED_OTHER) == opencmw::thread::Policy::OTHER);
+    REQUIRE(opencmw::thread::detail::getEnumPolicy(-1) == opencmw::thread::Policy::UNKNOWN);
+    REQUIRE(opencmw::thread::detail::getEnumPolicy(-2) == opencmw::thread::Policy::UNKNOWN);
+}
+
 TEST_CASE("basic thread affinity", "[ThreadAffinity]") {
     opencmw::debug::resetStats();
     opencmw::debug::Timer timer("ThreadAffinity - basic thread affinity", 40);

--- a/src/core/test/ThreadAffinity_tests.cpp
+++ b/src/core/test/ThreadAffinity_tests.cpp
@@ -122,6 +122,10 @@ TEST_CASE("ProcessSchedulingParameter", "[ThreadAffinity]") {
 
     REQUIRE_THROWS_AS(getProcessSchedulingParameter(-1), std::system_error);
     REQUIRE_THROWS_AS(setProcessSchedulingParameter(ROUND_ROBIN, 5, -1), std::system_error);
+
+    REQUIRE(opencmw::thread::detail::getEnumPolicy(SCHED_FIFO) == opencmw::thread::FIFO);
+    REQUIRE(opencmw::thread::detail::getEnumPolicy(SCHED_RR) == opencmw::thread::ROUND_ROBIN);
+    REQUIRE(opencmw::thread::detail::getEnumPolicy(SCHED_OTHER) == opencmw::thread::OTHER);
 }
 
 TEST_CASE("ThreadSchedulingParameter", "[ThreadAffinity]") {

--- a/src/core/test/ThreadAffinity_tests.cpp
+++ b/src/core/test/ThreadAffinity_tests.cpp
@@ -1,0 +1,155 @@
+#include <catch2/catch.hpp>
+#include <Debug.hpp>
+#include <fmt/chrono.h>
+#include <ThreadAffinity.hpp>
+
+#define REQUIRE_MESSAGE(cond, msg) \
+    do { \
+        INFO(msg); \
+        REQUIRE(cond); \
+    } while ((void) 0, 0)
+
+TEST_CASE("basic thread affinity", "[ThreadAffinity]") {
+    opencmw::debug::resetStats();
+    opencmw::debug::Timer timer("ThreadAffinity - basic thread affinity", 40);
+
+    using namespace opencmw;
+    std::atomic<bool>    run         = true;
+    const auto           dummyAction = [&run]() { while (run) { std::this_thread::sleep_for(std::chrono::milliseconds(50)); } };
+    std::jthread         testThread(dummyAction);
+
+    constexpr std::array threadMap = { true, false, false, false };
+    thread::setThreadAffinity(threadMap, testThread);
+    auto affinity = thread::getThreadAffinity(testThread);
+    bool equal    = true;
+    for (size_t i = 0; i < std::min(threadMap.size(), affinity.size()); i++) {
+        if (threadMap[i] != affinity[i]) {
+            equal = false;
+        }
+    }
+    REQUIRE_MESSAGE(equal, fmt::format("set {{{}}} affinity map does not match get {{{}}} map", fmt::join(threadMap, ", "), fmt::join(affinity, ", ")));
+
+    // tests w/o thread argument
+    constexpr std::array threadMapOn = { true, true };
+    thread::setThreadAffinity(threadMapOn);
+    affinity = thread::getThreadAffinity();
+    for (size_t i = 0; i < std::min(threadMapOn.size(), affinity.size()); i++) {
+        if (threadMapOn[i] != affinity[i]) {
+            equal = false;
+        }
+    }
+    REQUIRE_MESSAGE(equal, fmt::format("set {{{}}} affinity map does not match get {{{}}} map", fmt::join(threadMap, ", "), fmt::join(affinity, ", ")));
+
+    std::jthread bogusThread;
+    REQUIRE_THROWS_AS(thread::getThreadAffinity(bogusThread), std::system_error);
+    REQUIRE_THROWS_AS(thread::setThreadAffinity(threadMapOn, bogusThread), std::system_error);
+
+    run = false;
+}
+
+TEST_CASE("basic process affinity", "[ThreadAffinity]") {
+    opencmw::debug::resetStats();
+    opencmw::debug::Timer timer("ThreadAffinity - basic process affinity", 40);
+
+    using namespace opencmw;
+    constexpr std::array threadMap = { true, false, false, false };
+    thread::setProcessAffinity(threadMap);
+    auto affinity = thread::getProcessAffinity();
+    bool equal    = true;
+    for (size_t i = 0; i < std::min(threadMap.size(), affinity.size()); i++) {
+        if (threadMap[i] != affinity[i]) {
+            equal = false;
+        }
+    }
+    REQUIRE_MESSAGE(equal, fmt::format("set {{{}}} affinity map does not match get {{{}}} map", fmt::join(threadMap, ", "), fmt::join(affinity, ", ")));
+    constexpr std::array threadMapOn = { true, true, true, true };
+    thread::setProcessAffinity(threadMapOn);
+    REQUIRE_THROWS_AS(thread::getProcessAffinity(-1), std::system_error);
+    REQUIRE_THROWS_AS(thread::setProcessAffinity(threadMapOn, -1), std::system_error);
+}
+
+TEST_CASE("ThreadName", "[ThreadAffinity]") {
+    opencmw::debug::resetStats();
+    opencmw::debug::Timer timer("ThreadAffinity - ThreadName", 40);
+
+    using namespace opencmw;
+    REQUIRE("" != thread::getThreadName());
+    REQUIRE_NOTHROW(thread::setThreadName("testCoreName"));
+    REQUIRE("testCoreName" == thread::getThreadName());
+
+    std::atomic<bool> run         = true;
+    const auto        dummyAction = [&run]() { while (run) { std::this_thread::sleep_for(std::chrono::milliseconds(20)); } };
+    std::jthread      testThread(dummyAction);
+    REQUIRE("" != thread::getThreadName(testThread));
+    REQUIRE_NOTHROW(thread::setThreadName("testThreadName", testThread));
+    thread::setThreadName("testThreadName", testThread);
+    REQUIRE("testThreadName" == thread::getThreadName(testThread));
+
+    std::jthread uninitialisedTestThread;
+    REQUIRE_THROWS_AS(thread::getThreadName(uninitialisedTestThread), std::system_error);
+    REQUIRE_THROWS_AS(thread::setThreadName("name", uninitialisedTestThread), std::system_error);
+    run = false;
+}
+
+TEST_CASE("ProcessName", "[ThreadAffinity]") {
+    opencmw::debug::resetStats();
+    opencmw::debug::Timer timer("ThreadAffinity - ProcessName", 40);
+
+    using namespace opencmw;
+    REQUIRE("" != thread::getProcessName());
+    REQUIRE(thread::getProcessName() == thread::getProcessName(thread::detail::getPid()));
+
+    REQUIRE_NOTHROW(thread::setProcessName("TestProcessName"));
+    REQUIRE("TestProcessName" == thread::getProcessName());
+}
+
+TEST_CASE("ProcessSchedulingParameter", "[ThreadAffinity]") {
+    opencmw::debug::resetStats();
+    opencmw::debug::Timer timer("ThreadAffinity - ProcessSchedParameter", 40);
+
+    using namespace opencmw::thread;
+    struct SchedulingParameter param = getProcessSchedulingParameter();
+    REQUIRE(param.policy == OTHER);
+    REQUIRE(param.priority == 0);
+
+    REQUIRE_NOTHROW(setProcessSchedulingParameter(OTHER, 0));
+    REQUIRE_THROWS_AS(setProcessSchedulingParameter(OTHER, 0, -1), std::system_error);
+    REQUIRE_THROWS_AS(setProcessSchedulingParameter(OTHER, 4), std::system_error);
+    REQUIRE_THROWS_AS(setProcessSchedulingParameter(ROUND_ROBIN, 5), std::system_error); // missing rights -- because most users do not have CAP_SYS_NICE rights by default -- hard to unit-test
+    param = getProcessSchedulingParameter();
+    REQUIRE(param.policy == OTHER);
+    REQUIRE(param.priority == 0);
+
+    REQUIRE_THROWS_AS(getProcessSchedulingParameter(-1), std::system_error);
+    REQUIRE_THROWS_AS(setProcessSchedulingParameter(ROUND_ROBIN, 5, -1), std::system_error);
+}
+
+TEST_CASE("ThreadSchedulingParameter", "[ThreadAffinity]") {
+    opencmw::debug::resetStats();
+    opencmw::debug::Timer timer("ThreadAffinity - ThreadSchedParameter", 40);
+
+    std::atomic<bool>     run         = true;
+    const auto            dummyAction = [&run]() { while (run) { std::this_thread::sleep_for(std::chrono::milliseconds(50)); } };
+    std::jthread          testThread(dummyAction);
+    std::jthread          bogusThread;
+
+    using namespace opencmw::thread;
+    struct SchedulingParameter param = getThreadSchedulingParameter(testThread);
+    REQUIRE(param.policy == OTHER);
+    REQUIRE(param.priority == 0);
+
+    REQUIRE_NOTHROW(setThreadSchedulingParameter(OTHER, 0, testThread));
+    REQUIRE_NOTHROW(setThreadSchedulingParameter(OTHER, 0));
+    REQUIRE_THROWS_AS(setThreadSchedulingParameter(OTHER, 0, bogusThread), std::system_error);
+    REQUIRE_THROWS_AS(setThreadSchedulingParameter(OTHER, 4, testThread), std::system_error);
+    REQUIRE_THROWS_AS(setThreadSchedulingParameter(OTHER, 4), std::system_error);
+    REQUIRE_THROWS_AS(setThreadSchedulingParameter(ROUND_ROBIN, 5, testThread), std::system_error); // missing rights -- because most users do not have CAP_SYS_NICE rights by default -- hard to unit-test
+    REQUIRE_THROWS_AS(setThreadSchedulingParameter(ROUND_ROBIN, 5), std::system_error);             // missing rights -- because most users do not have CAP_SYS_NICE rights by default -- hard to unit-test
+    param = getThreadSchedulingParameter(testThread);
+    REQUIRE(param.policy == OTHER);
+
+    REQUIRE_THROWS_AS(getThreadSchedulingParameter(bogusThread), std::system_error);
+    REQUIRE_THROWS_AS(setThreadSchedulingParameter(ROUND_ROBIN, 5, bogusThread), std::system_error);
+
+    run = false;
+}


### PR DESCRIPTION
N.B. assumes UNIX/POSIX threads for the time being, other OSes are nullopts

* non-root users may need SYS_CAP_NICE capabilities being set for the given application in order to make use of the FIFO and ROUND_ROBIN scheduling policies:

sudo setcap 'cap_sys_nice=eip' <application>