### PR TITLE
YaS Serialiser addons

### DIFF
--- a/src/serialiser/include/IoBuffer.hpp
+++ b/src/serialiser/include/IoBuffer.hpp
@@ -259,7 +259,7 @@ public:
 
     template<StringLike R>
     [[nodiscard]] R get() noexcept {
-        const std::size_t bytesToCopy = static_cast<std::size_t>(get<int32_t>()) * sizeof(char);
+        const std::size_t bytesToCopy = std::min(static_cast<std::size_t>(get<int32_t>()) * sizeof(char), _size - _position);
         const std::size_t oldPosition = _position;
 #ifdef NDEBUG
         _position += bytesToCopy;
@@ -273,7 +273,7 @@ public:
 
     template<StringLike R>
     [[nodiscard]] R get(const std::size_t &index) noexcept {
-        const std::size_t bytesToCopy = static_cast<std::size_t>(get<int32_t>()) * sizeof(char);
+        const std::size_t bytesToCopy = std::min(static_cast<std::size_t>(get<int32_t>()) * sizeof(char), _size - _position);
 #ifndef NDEBUG
         _position += bytesToCopy - 1;
         const int8_t terminatingChar = get<int8_t>();
@@ -284,7 +284,7 @@ public:
 
     template<SupportedType R>
     constexpr std::vector<R> &getArray(std::vector<R> &input, const std::size_t &requestedSize = SIZE_MAX) noexcept {
-        const auto        arraySize    = static_cast<std::size_t>(get<int32_t>());
+        const auto        arraySize    = std::min(static_cast<std::size_t>(get<int32_t>()), _size - _position);
         const std::size_t minArraySize = std::min(arraySize, requestedSize);
         input.resize(minArraySize);
         if constexpr (is_stringlike<R> || is_same_v<R, bool>) {
@@ -303,7 +303,7 @@ public:
 
     template<SupportedType R, std::size_t size>
     constexpr std::array<R, size> &getArray(std::array<R, size> &input, const std::size_t &requestedSize = SIZE_MAX) noexcept {
-        const auto        arraySize    = static_cast<std::size_t>(get<int32_t>());
+        const auto        arraySize    = std::min(static_cast<std::size_t>(get<int32_t>()), _size - _position);
         const std::size_t minArraySize = std::min(arraySize, requestedSize);
         assert(size >= minArraySize && "std::array<SupportedType, size> wire-format size does not match design");
         if constexpr (is_stringlike<R> || is_same_v<R, bool>) {

--- a/src/serialiser/include/IoBuffer.hpp
+++ b/src/serialiser/include/IoBuffer.hpp
@@ -24,7 +24,7 @@ private:
     mutable std::size_t _position            = 0;
     std::size_t         _size                = 0;
     std::size_t         _capacity            = 0;
-    uint8_t *           _buffer              = nullptr;
+    uint8_t            *_buffer              = nullptr;
 
     constexpr void      reallocate(const std::size_t &size) noexcept {
         if (_capacity == size && _buffer != nullptr) {
@@ -59,7 +59,7 @@ private:
                 delete[] _buffer;
             }
         } else {
-            //throw std::runtime_error("double free"); //TODO: reenable
+            // throw std::runtime_error("double free"); //TODO: reenable
         }
         _buffer = nullptr;
     }
@@ -133,15 +133,15 @@ public:
         return *this;
     }
 
-    constexpr uint8_t &                        operator[](const std::size_t i) { return _buffer[i]; }
-    constexpr const uint8_t &                  operator[](const std::size_t i) const { return _buffer[i]; }
+    constexpr uint8_t                         &operator[](const std::size_t i) { return _buffer[i]; }
+    constexpr const uint8_t                   &operator[](const std::size_t i) const { return _buffer[i]; }
     constexpr void                             reset() { _position = 0; }
     constexpr void                             set_position(size_t position) { _position = position; }
     [[nodiscard]] constexpr const std::size_t &position() const { return _position; }
     [[nodiscard]] constexpr const std::size_t &capacity() const { return _capacity; }
     [[nodiscard]] constexpr const std::size_t &size() const { return _size; }
-    [[nodiscard]] constexpr uint8_t *          data() noexcept { return _buffer; }
-    [[nodiscard]] constexpr const uint8_t *    data() const noexcept { return _buffer; }
+    [[nodiscard]] constexpr uint8_t           *data() noexcept { return _buffer; }
+    [[nodiscard]] constexpr const uint8_t     *data() const noexcept { return _buffer; }
     constexpr void                             clear() noexcept { _position = _size = 0; }
 
     template<typename R>
@@ -197,13 +197,13 @@ public:
     }
 
     template<SupportedType I, size_t size>
-    constexpr void put(I const (&values)[size]) noexcept { put(values, size); } //NOLINT int a[30]; OK <-> std::array<int, 30>
+    constexpr void put(I const (&values)[size]) noexcept { put(values, size); } // NOLINT int a[30]; OK <-> std::array<int, 30>
     template<SupportedType I>
     constexpr void put(std::vector<I> const &values) noexcept { put(values.data(), values.size()); }
     template<SupportedType I, size_t size>
     constexpr void put(std::array<I, size> const &values) noexcept { put(values.data(), size); }
 
-    void           put(std::vector<bool> const &values) noexcept { //TODO: re-enable constexpr (N.B. should be since C++20)
+    void           put(std::vector<bool> const &values) noexcept { // TODO: re-enable constexpr (N.B. should be since C++20)
         const std::size_t size       = values.size();
         const std::size_t byteToCopy = size * sizeof(bool);
         reserve_spare(byteToCopy + sizeof(int32_t) + sizeof(bool));
@@ -333,4 +333,4 @@ public:
 } // namespace opencmw
 
 #pragma clang diagnostic pop
-#endif //OPENCMW_IOBUFFER_H
+#endif // OPENCMW_IOBUFFER_H

--- a/src/serialiser/include/IoSerialiser.hpp
+++ b/src/serialiser/include/IoSerialiser.hpp
@@ -352,7 +352,6 @@ constexpr DeserialiserInfo deserialise(IoBuffer &buffer, T &value, DeserialiserI
             }
             using MemberType = std::remove_reference_t<decltype(getAnnotatedMember(unwrapPointer(member(value))))>;
             if constexpr (isReflectableClass<MemberType>() || !is_writable(member) || is_static(member)) {
-                handleError<protocolCheckVariant>(info, "field is not writeable or non-primitive: {}", member.name);
                 if (field.dataEndPosition != std::numeric_limits<size_t>::max()) {
                     buffer.set_position(field.dataEndPosition);
                 }

--- a/src/serialiser/include/IoSerialiser.hpp
+++ b/src/serialiser/include/IoSerialiser.hpp
@@ -79,10 +79,10 @@ template<SerialiserProtocol protocol, typename T>
 struct IoSerialiser {
     constexpr static uint8_t getDataTypeId() { return 0xFF; } // default value
 
-    constexpr static bool    serialise(IoBuffer & /*buffer*/, const ClassField &field, const T &value) noexcept {
+    constexpr static bool    serialise(IoBuffer    &/*buffer*/, const ClassField &field, const T &value) noexcept {
         std::cout << fmt::format("{:<4} - serialise-generic: {} {} value: {} - constexpr?: {}\n",
-                protocol::protocolName(), typeName<T>, field, value,
-                std::is_constant_evaluated());
+                   protocol::protocolName(), typeName<T>, field, value,
+                   std::is_constant_evaluated());
         return std::is_constant_evaluated();
     }
 
@@ -396,7 +396,7 @@ constexpr DeserialiserInfo deserialise(IoBuffer &buffer, T &value, DeserialiserI
                     info.setFields[structName][static_cast<uint64_t>(searchIndex)] = true;
                 }
             }
-        });
+          });
 #pragma clang diagnostic pop
         // skip to data end if field header defines the end
         if (field.dataEndPosition != std::numeric_limits<size_t>::max() && field.dataEndPosition != buffer.position()) {

--- a/src/serialiser/include/IoSerialiserYaS.hpp
+++ b/src/serialiser/include/IoSerialiserYaS.hpp
@@ -57,7 +57,6 @@ template<> inline constexpr uint8_t getDataTypeId<std::string_view[]>() { return
 // template<> inline constexpr uint8_t getDataTypeId<START_MARKER>() { return 200; }
 // template<> inline constexpr uint8_t getDataTypeId<enum>()          { return 201; }
 // template<typename T> inline constexpr uint8_t getDataTypeId<std::list<T>>()     { return 202; }
-// template<> inline constexpr uint8_t getDataTypeId<std::unsorted_map>() { return 203; }
 // template<> inline constexpr uint8_t getDataTypeId<std::queue>()    { return 204; }
 // template<> inline constexpr uint8_t getDataTypeId<std::set>()      { return 205; }
 
@@ -78,7 +77,7 @@ struct IoSerialiser<YaS, T> {
 template<Number T> // catches all numbers
 struct IoSerialiser<YaS, T> {
     inline static constexpr uint8_t getDataTypeId() { return yas::getDataTypeId<T>(); }
-    constexpr static bool           serialise(IoBuffer &buffer, const ClassField & /*field*/, const T &value) noexcept {
+    constexpr static bool           serialise(IoBuffer &buffer, const ClassField           &/*field*/, const T &value) noexcept {
         buffer.put(value);
         return std::is_constant_evaluated();
     }
@@ -91,7 +90,7 @@ struct IoSerialiser<YaS, T> {
 template<StringLike T>
 struct IoSerialiser<YaS, T> {
     inline static constexpr uint8_t getDataTypeId() { return yas::getDataTypeId<T>(); }
-    constexpr static bool           serialise(IoBuffer &buffer, const ClassField & /*field*/, const T &value) noexcept {
+    constexpr static bool           serialise(IoBuffer &buffer, const ClassField           &/*field*/, const T &value) noexcept {
         buffer.put<T>(value); // N.B. ensure that the wrapped value and not the annotation itself is serialised
         return std::is_constant_evaluated();
     }
@@ -104,7 +103,7 @@ struct IoSerialiser<YaS, T> {
 template<ArrayOrVector T>
 struct IoSerialiser<YaS, T> {
     inline static constexpr uint8_t getDataTypeId() { return yas::getDataTypeId<T>(); }
-    constexpr static bool           serialise(IoBuffer &buffer, const ClassField & /*field*/, const T &value) noexcept {
+    constexpr static bool           serialise(IoBuffer &buffer, const ClassField           &/*field*/, const T &value) noexcept {
         buffer.put(std::array<int32_t, 1>{ static_cast<int32_t>(value.size()) });
         buffer.put(value);
         return std::is_constant_evaluated();
@@ -148,11 +147,110 @@ struct IoSerialiser<YaS, T> {
     }
 };
 
+template<MapLike T>
+struct IoSerialiser<YaS, T> {
+    inline static constexpr uint8_t getDataTypeId() { return 203; }
+    constexpr static bool           serialise(IoBuffer &buffer, const ClassField &field, const T &value) noexcept {
+        using K                 = typename T::key_type;
+        using V                 = typename T::mapped_type;
+        const int32_t nElements = static_cast<int32_t>(value.size());
+        buffer.put(std::array<int32_t, 1>{ nElements }); // [ndims]{size}
+        buffer.put(nElements);                           // nElements
+
+        if constexpr (is_supported_number<K> || is_stringlike<K>) {
+            constexpr int entrySize = 17; // as an initial estimate
+            buffer.reserve_spare(static_cast<size_t>(nElements * entrySize + 9));
+            buffer.put(static_cast<uint8_t>(yas::getDataTypeId<K>())); // type-id
+            buffer.put(nElements);                                     // nElements
+            for (auto &entry : value) {
+                buffer.put(entry.first);
+            }
+        } else {                                     // non-primitive or non-string-like types
+            buffer.put(yas::getDataTypeId<OTHER>()); // type-id
+            buffer.put(typeName<K>());               // primary type
+            buffer.put("");                          // secondary type (if any) TODO: add appropriate
+            buffer.put(nElements);
+            for (auto &entry : value) {
+                IoSerialiser<YaS, K>::serialise(buffer, field, entry.first);
+            }
+        }
+
+        if constexpr (is_supported_number<V> || is_stringlike<V>) {
+            constexpr int entrySize = 17; // as an initial estimate
+            buffer.reserve_spare(static_cast<size_t>(nElements * entrySize + 9));
+            buffer.put(static_cast<uint8_t>(yas::getDataTypeId<V>()));
+            buffer.put(nElements);
+            for (auto &entry : value) {
+                buffer.put(entry.second);
+            }
+        } else {                                         // non-primitive or non-string-like types
+            buffer.put(yas::getDataTypeId<OTHER>());     // type-id
+            buffer.put(typeName<V>());                   // primary type
+            buffer.put("");                              // secondary type (if any) TODO: add appropriate
+            buffer.put(static_cast<int32_t>(nElements)); // nElements
+            for (auto &entry : value) {
+                IoSerialiser<YaS, K>::serialise(buffer, field, entry.second);
+            }
+        }
+        return std::is_constant_evaluated();
+    }
+    static bool deserialise(IoBuffer &buffer, const ClassField &field, T &value) {
+        using K                  = typename T::key_type;
+        using V                  = typename T::mapped_type;
+        const auto     dimWire   = buffer.getArray<int32_t>(); // [ndims]{size}
+        const auto     nElements = static_cast<uint32_t>(buffer.get<int32_t>());
+
+        const auto     keyType   = buffer.get<uint8_t>();
+        std::vector<K> keys;
+        keys.reserve(nElements);
+        if constexpr (is_supported_number<K> || is_stringlike<K>) {
+            if (yas::getDataTypeId<K>() != keyType) {
+                throw new ProtocolException(fmt::format("key type mismatch for field {} - required {} ({}) vs. have {}", field, yas::getDataTypeId<K>(), typeid(K).name(), keyType));
+            }
+            const auto nElementsCheck = static_cast<uint32_t>(buffer.get<int32_t>());
+            if (nElements != nElementsCheck) {
+                throw new ProtocolException(fmt::format("key array length mismatch for field {} - required {} vs. have {}", field, nElements, nElementsCheck));
+            }
+            for (auto i = 0U; i < nElementsCheck; i++) {
+                keys.emplace_back(buffer.get<K>());
+            }
+        } else if (keyType == yas::getDataTypeId<OTHER>()) {
+            throw new ProtocolException(fmt::format("key type OTHER for field {} not yet implemented", field));
+        } else {
+            throw new ProtocolException(fmt::format("unsupported key type {} for field {}", keyType, field));
+        }
+
+        const auto valueType = buffer.get<uint8_t>();
+        if constexpr (is_supported_number<V> || is_stringlike<V>) {
+            if (yas::getDataTypeId<K>() != keyType) {
+                throw new ProtocolException(fmt::format("value type mismatch for field {} - required {} ({}) vs. have {}", field, yas::getDataTypeId<V>(), typeid(V).name(), valueType));
+            }
+            const auto nElementsCheck = static_cast<uint32_t>(buffer.get<int32_t>());
+            if (nElements != nElementsCheck) {
+                throw new ProtocolException(fmt::format("value array length mismatch for field {} - required {} vs. have {}", field, nElements, nElementsCheck));
+            }
+            value.clear();
+            for (auto i = 0U; i < nElementsCheck; i++) {
+                auto v         = buffer.get<V>();
+                value[keys[i]] = v;
+            }
+        } else if (keyType == yas::getDataTypeId<OTHER>()) {
+            throw new ProtocolException(fmt::format("value type OTHER for field {} not yet implemented", field));
+        } else {
+            throw new ProtocolException(fmt::format("unsupported key type {} for field {}", keyType, field));
+        }
+
+        fmt::print("keyType {} valueType {}", keyType, valueType);
+
+        return std::is_constant_evaluated();
+    }
+};
+
 template<>
 struct IoSerialiser<YaS, START_MARKER> {
     inline static constexpr uint8_t getDataTypeId() { return yas::getDataTypeId<START_MARKER>(); }
 
-    constexpr static bool           serialise(IoBuffer & /*buffer*/, const ClassField & /*field*/, const START_MARKER & /*value*/) noexcept {
+    constexpr static bool           serialise(IoBuffer           &/*buffer*/, const ClassField           &/*field*/, const START_MARKER           &/*value*/) noexcept {
         // do not do anything, as the start marker is of size zero and only the type byte is important
         return std::is_constant_evaluated();
     }
@@ -166,7 +264,7 @@ struct IoSerialiser<YaS, START_MARKER> {
 template<>
 struct IoSerialiser<YaS, END_MARKER> {
     inline static constexpr uint8_t getDataTypeId() { return yas::getDataTypeId<END_MARKER>(); }
-    static bool                     serialise(IoBuffer & /*buffer*/, const ClassField & /*field*/, const END_MARKER & /*value*/) noexcept {
+    static bool                     serialise(IoBuffer                     &/*buffer*/, const ClassField                     &/*field*/, const END_MARKER                     &/*value*/) noexcept {
         // do not do anything, as the end marker is of size zero and only the type byte is important
         return std::is_constant_evaluated();
     }
@@ -234,7 +332,7 @@ inline void putHeaderInfo<YaS>(IoBuffer &buffer) {
 
 template<>
 inline DeserialiserInfo checkHeaderInfo<YaS>(IoBuffer &buffer, DeserialiserInfo info, const ProtocolCheck protocolCheckVariant) {
-    const auto magic      = buffer.get<int>();
+    const auto magic = buffer.get<int>();
     if (yas::VERSION_MAGIC_NUMBER != magic) {
         if (protocolCheckVariant == LENIENT) {
             info.exceptions.template emplace_back(ProtocolException(fmt::format("Wrong serialiser magic number: {} != -1", magic)));
@@ -254,9 +352,9 @@ inline DeserialiserInfo checkHeaderInfo<YaS>(IoBuffer &buffer, DeserialiserInfo 
         }
         return info;
     }
-    auto ver_major  = buffer.get<int8_t>();
-    auto ver_minor  = buffer.get<int8_t>();
-    auto ver_micro  = buffer.get<int8_t>();
+    auto ver_major = buffer.get<int8_t>();
+    auto ver_minor = buffer.get<int8_t>();
+    auto ver_micro = buffer.get<int8_t>();
     if (yas::VERSION_MAJOR != ver_major) {
         if (protocolCheckVariant == LENIENT) {
             info.exceptions.template emplace_back(ProtocolException(fmt::format("Major versions do not match, received {}.{}.{}", ver_major, ver_minor, ver_micro)));

--- a/src/serialiser/include/IoSerialiserYaS.hpp
+++ b/src/serialiser/include/IoSerialiserYaS.hpp
@@ -234,11 +234,7 @@ inline void putHeaderInfo<YaS>(IoBuffer &buffer) {
 
 template<>
 inline DeserialiserInfo checkHeaderInfo<YaS>(IoBuffer &buffer, DeserialiserInfo info, const ProtocolCheck protocolCheckVariant) {
-    auto magic      = buffer.get<int>();
-    auto proto_name = buffer.get<std::string>();
-    auto ver_major  = buffer.get<int8_t>();
-    auto ver_minor  = buffer.get<int8_t>();
-    auto ver_micro  = buffer.get<int8_t>();
+    const auto magic      = buffer.get<int>();
     if (yas::VERSION_MAGIC_NUMBER != magic) {
         if (protocolCheckVariant == LENIENT) {
             info.exceptions.template emplace_back(ProtocolException(fmt::format("Wrong serialiser magic number: {} != -1", magic)));
@@ -246,7 +242,9 @@ inline DeserialiserInfo checkHeaderInfo<YaS>(IoBuffer &buffer, DeserialiserInfo 
         if (protocolCheckVariant == ALWAYS) {
             throw ProtocolException(fmt::format("Wrong serialiser magic number: {} != -1", magic));
         }
+        return info;
     }
+    auto proto_name = buffer.get<std::string>();
     if (yas::PROTOCOL_NAME != proto_name) {
         if (protocolCheckVariant == LENIENT) {
             info.exceptions.template emplace_back(ProtocolException(fmt::format("Wrong serialiser identification string: {} != YaS", proto_name)));
@@ -254,7 +252,11 @@ inline DeserialiserInfo checkHeaderInfo<YaS>(IoBuffer &buffer, DeserialiserInfo 
         if (protocolCheckVariant == ALWAYS) {
             throw ProtocolException(fmt::format("Wrong serialiser identification string: {} != YaS", proto_name));
         }
+        return info;
     }
+    auto ver_major  = buffer.get<int8_t>();
+    auto ver_minor  = buffer.get<int8_t>();
+    auto ver_micro  = buffer.get<int8_t>();
     if (yas::VERSION_MAJOR != ver_major) {
         if (protocolCheckVariant == LENIENT) {
             info.exceptions.template emplace_back(ProtocolException(fmt::format("Major versions do not match, received {}.{}.{}", ver_major, ver_minor, ver_micro)));
@@ -262,6 +264,7 @@ inline DeserialiserInfo checkHeaderInfo<YaS>(IoBuffer &buffer, DeserialiserInfo 
         if (protocolCheckVariant == ALWAYS) {
             throw ProtocolException(fmt::format("Major versions do not match, received {}.{}.{}", ver_major, ver_minor, ver_micro));
         }
+        return info;
     }
     return info;
 }

--- a/src/serialiser/include/opencmw.hpp
+++ b/src/serialiser/include/opencmw.hpp
@@ -3,6 +3,7 @@
 #include "MultiArray.hpp" // TODO: resolve dangerous circular dependency
 #include <fmt/color.h>
 #include <fmt/format.h>
+#include <map>
 #include <refl.hpp>
 #include <set>
 #include <units/concepts.h>
@@ -64,6 +65,18 @@ concept ArithmeticType = std::is_arithmetic_v<Tp>;
 
 template<typename T>
 concept SupportedType = is_supported_number<T> || is_stringlike<T>;
+
+template<template<typename...> class Template, typename Class>
+struct is_instantiation : std::false_type {};
+
+template<template<typename...> class Template, typename... Args>
+struct is_instantiation<Template, Template<Args...>> : std::true_type {};
+
+template<typename Class, template<typename...> class Template>
+concept is_instantiation_of = is_instantiation<Template, Class>::value;
+
+template<typename T>
+concept MapLike = is_instantiation_of<T, std::map> || is_instantiation_of<T, std::unordered_map>;
 
 template<typename T>
 inline constexpr const bool is_array = false;
@@ -369,6 +382,9 @@ template<typename T, typename A> const std::string &typeName<std::vector<T,A> co
 
 template<typename T, uint32_t N> const std::string &typeName<MultiArray<T,N>> = fmt::format("MultiArray<{},{}>", opencmw::typeName<T>, N);
 template<typename T, uint32_t N> const std::string &typeName<MultiArray<T,N> const> =  fmt::format("MultiArray<{},{}> const", opencmw::typeName<T>, N);
+
+template<MapLike T> const std::string &typeName<T> =  fmt::format("map<{},{}>", opencmw::typeName<typename T::key_type>, opencmw::typeName<typename T::mapped_type>);
+template<MapLike T> const std::string &typeName<T const> =  fmt::format("map<{},{}> const", opencmw::typeName<typename T::key_type>, opencmw::typeName<typename T::mapped_type>);
 
 template<typename T, units::Quantity Q, const basic_fixed_string description, const ExternalModifier modifier, const basic_fixed_string... groups>
 const std::string &typeName<Annotated<T, Q, description, modifier, groups...>> = fmt::format("Annotated<{}>", opencmw::typeName<T>);

--- a/src/serialiser/test/IoSerialiserYaS_tests.cpp
+++ b/src/serialiser/test/IoSerialiserYaS_tests.cpp
@@ -2,13 +2,13 @@
 #pragma ide diagnostic   ignored "LoopDoesntUseConditionVariableInspection"
 #pragma ide diagnostic   ignored "cppcoreguidelines-avoid-magic-numbers"
 
-#include <Debug.hpp>
-#include <IoSerialiserYaS.hpp>
-#include <Utils.hpp>
 #include <algorithm>
 #include <catch2/catch.hpp>
+#include <Debug.hpp>
+#include <IoSerialiserYaS.hpp>
 #include <iostream>
 #include <string_view>
+#include <Utils.hpp>
 
 #include <units/isq/si/electric_current.h>
 #include <units/isq/si/energy.h>
@@ -151,7 +151,7 @@ struct NestedDataWithDifferences {
     Annotated<double, mass<kilogram>, "custom description for double", RO>        annDoubleValue = 16.0;                         // <- read-only specifier
     Annotated<std::string, NoUnit, "deprecation notice", RW_DEPRECATED>           annStringValue = std::string("nested string"); // <- extra deprecation specifier
     Annotated<std::array<double, 10>, NoUnit, "private field notice", RW_PRIVATE> annDoubleArray = std::array<double, 10>{ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
-    //Annotated<std::vector<float>, NoUnit>                                                annFloatVector; // <- missing field
+    // Annotated<std::vector<float>, NoUnit>                                                annFloatVector; // <- missing field
     Annotated<std::string, NoUnit, "custom description for string"> annExtraValue = std::string("nested string"); // <- extra value
 
     // some default operator
@@ -361,7 +361,7 @@ TEST_CASE("IoClassSerialiser smart pointer", "[IoClassSerialiser]") {
         //        std::cout << "type B" << typeName<TypeB> << std::endl;
         //        std::cout << "Rep   " << typeName<Rep> << std::endl;
         //        std::cout << "quantity " << typeName<units::detail::common_quantity_impl<TypeA, TypeB, Rep>::type> << std::endl;
-        //data.e1        = data.e1 + data.e1;
+        // data.e1        = data.e1 + data.e1;
         *data.e2.get() = *data.e2.get() + 10;
         *data.e3.get() = *data.e3.get() + 10;
         *data.e4.get() = *data.e4.get() + 10;
@@ -407,7 +407,7 @@ TEST_CASE("IoSerialiser syntax", "[IoSerialiser]") {
         std::cout << "type name: " << opencmw::typeName<std::byte> << '\n';
         std::cout << "type name: " << opencmw::typeName<char> << '\n';
         std::cout << "type name: " << opencmw::typeName<const char> << '\n';
-        std::cout << "type name: " << opencmw::typeName<int[2]> << '\n'; //NOLINT
+        std::cout << "type name: " << opencmw::typeName<int[2]> << '\n'; // NOLINT
         const int a[2] = { 1, 2 };
         std::cout << "type name: " << opencmw::typeName<decltype(a)> << '\n';
         std::cout << "type name: " << opencmw::typeName<short *> << '\n';
@@ -500,6 +500,27 @@ TEST_CASE("IoSerialiser primitive numbers YaS", "[IoSerialiser]") {
     }
     REQUIRE(opencmw::debug::dealloc == opencmw::debug::alloc); // a memory leak occurred
     opencmw::debug::resetStats();
+}
+
+TEST_CASE("IoClassSerialiser protocol error tests", "[IoClassSerialiser]") {
+    using namespace opencmw;
+    using namespace opencmw::utils; // for operator<< and fmt::format overloading
+    IoBuffer buffer;
+    Data     data;
+
+    Data     data2;
+    REQUIRE(data == data2);
+    data.stringValue = "changed";
+    REQUIRE(data != data2);
+
+    opencmw::serialise<opencmw::YaS>(buffer, data);
+
+    buffer.reset();
+    auto info = opencmw::deserialise<YaS, ProtocolCheck::LENIENT>(buffer, data2);
+    std::cout << " info: {}\n"
+              << info << std::endl;
+    REQUIRE(info.exceptions.size() == 0);
+    //    REQUIRE(data == data2);
 }
 
 #pragma clang diagnostic pop

--- a/src/serialiser/test/IoSerialiserYaS_tests.cpp
+++ b/src/serialiser/test/IoSerialiserYaS_tests.cpp
@@ -518,8 +518,6 @@ TEST_CASE("IoClassSerialiser protocol error tests", "[IoClassSerialiser]") {
     {
         buffer.reset();
         auto info = opencmw::deserialise<YaS, ProtocolCheck::LENIENT>(buffer, data2);
-        std::cout << " info: {}\n"
-                  << info << std::endl;
         REQUIRE(info.exceptions.size() == 0);
     }
 
@@ -531,7 +529,7 @@ TEST_CASE("IoClassSerialiser protocol error tests", "[IoClassSerialiser]") {
         auto info = opencmw::deserialise<YaS, ProtocolCheck::LENIENT>(buffer, data2);
         std::cout << " info: {}\n"
                   << info << std::endl;
-        REQUIRE(info.exceptions.size() == 0);
+        REQUIRE(info.exceptions.size() == 1); // N.B. invalid protocol
     }
 }
 

--- a/src/serialiser/test/IoSerialiserYaS_tests.cpp
+++ b/src/serialiser/test/IoSerialiserYaS_tests.cpp
@@ -515,12 +515,24 @@ TEST_CASE("IoClassSerialiser protocol error tests", "[IoClassSerialiser]") {
 
     opencmw::serialise<opencmw::YaS>(buffer, data);
 
-    buffer.reset();
-    auto info = opencmw::deserialise<YaS, ProtocolCheck::LENIENT>(buffer, data2);
-    std::cout << " info: {}\n"
-              << info << std::endl;
-    REQUIRE(info.exceptions.size() == 0);
-    //    REQUIRE(data == data2);
+    {
+        buffer.reset();
+        auto info = opencmw::deserialise<YaS, ProtocolCheck::LENIENT>(buffer, data2);
+        std::cout << " info: {}\n"
+                  << info << std::endl;
+        REQUIRE(info.exceptions.size() == 0);
+    }
+
+    buffer.clear();
+    buffer.putRaw(R"({ "float1": 2.3, "test": { "intArray": [1, 2, 3], "val1":13.37e2, "val2":"bar"}, "int1": 42})");
+    std::cout << "Prepared json data: " << buffer.asString() << std::endl;
+    {
+        buffer.reset();
+        auto info = opencmw::deserialise<YaS, ProtocolCheck::LENIENT>(buffer, data2);
+        std::cout << " info: {}\n"
+                  << info << std::endl;
+        REQUIRE(info.exceptions.size() == 0);
+    }
 }
 
 #pragma clang diagnostic pop

--- a/src/utils/include/Utils.hpp
+++ b/src/utils/include/Utils.hpp
@@ -76,7 +76,7 @@ inline std::ostream &ClassInfoIndentDec(std::ostream &os) {
 }
 
 template<ArrayOrVector T>
-//requires (!isAnnotated<T>())
+// requires (!isAnnotated<T>())
 inline std::ostream &operator<<(std::ostream &os, const T &v) {
     os << '{';
     for (std::size_t i = 0; i < v.size(); ++i) {
@@ -121,6 +121,22 @@ inline std::ostream &operator<<(std::ostream &os, const std::shared_ptr<T> &v) {
     }
 }
 
+template<MapLike T>
+inline std::ostream &operator<<(std::ostream &os, const T &map) {
+    os << '{';
+    bool first = true;
+    for (auto const &[key, val] : map) {
+        if (first) {
+            first = false;
+        } else {
+            os << ", ";
+        }
+        os << key << ':' << val;
+    }
+    os << "}";
+    return os;
+}
+
 template<ReflectableClass T>
 inline std::ostream &operator<<(std::ostream &os, const T &value) {
     const bool    verbose    = os.iword(getClassInfoVerbose());
@@ -133,7 +149,7 @@ inline std::ostream &operator<<(std::ostream &os, const T &value) {
                 refl::reflect(value).members, [&](const auto member, const auto index) constexpr {
                     using MemberType          = std::remove_reference_t<decltype(unwrapPointer(member(value)))>;
                     const auto &typeNameShort = typeName<MemberType>;
-                    //const auto& typeNameShort = refl::reflect(getAnnotatedMember(member(value))).name.data; // alt type-definition:
+                    // const auto& typeNameShort = refl::reflect(getAnnotatedMember(member(value))).name.data; // alt type-definition:
                     if (verbose) {
                         os << fmt::format("{:{}} {}: {:<25} {:<35}= ", "", indent * indentStep + 1, index, typeNameShort, get_debug_name(member));
                     } else {
@@ -204,7 +220,6 @@ inline constexpr void diffView(std::ostream &os, const T &lhs, const T &rhs) {
         if (lhsValue == rhsValue) {
             os << lhsValue;
         } else {
-            //os << fmt::format("{} vs. ", lhsValue) << rhs;
             os << fmt::format(fg(fmt::color::red), "{} vs. {}", lhsValue, rhsValue); // coloured terminal output
         }
     }
@@ -254,4 +269,4 @@ struct fmt::formatter<T> {
     }
 };
 
-#endif //OPENCMW_UTILS_H
+#endif // OPENCMW_UTILS_H


### PR DESCRIPTION
* fixed IoBuffer with JSON content tripping the YaS protocol
* added additional checks against potential out-of-bound reads for bulk operations in IoBuffer
* changed throwing exception to skipping writing into `const` marker fields

work-in-progress:
 * adding (de-)Serialiser definitions for std::unordered_map and other primitives already implemented on the Java side