### PR TITLE
WIP terminate on invalid JSON

### DIFF
--- a/src/serialiser/include/IoSerialiserJson.hpp
+++ b/src/serialiser/include/IoSerialiserJson.hpp
@@ -453,6 +453,8 @@ struct FieldHeaderReader<Json> {
             result.dataEndPosition   = std::numeric_limits<size_t>::max(); // not defined for non-skippable data
             return;
         }
+
+        detail::handleDeserialisationError<protocolCheckVariant>(info, "json malformed, unexpected '{}' at buffer position {}", buffer.at<char>(buffer.position()), buffer.position());
         return;
     }
 };

--- a/src/serialiser/test/IoSerialiserJson_tests.cpp
+++ b/src/serialiser/test/IoSerialiserJson_tests.cpp
@@ -70,6 +70,31 @@ TEST_CASE("JsonDeserialisation", "[JsonSerialiser]") {
     opencmw::debug::resetStats();
 }
 
+struct SimpleId {
+    int id;
+};
+
+ENABLE_REFLECTION_FOR(SimpleId, id)
+
+TEST_CASE("JsonDeserialisationInvalidJson", "[JsonSerialiser]") {
+    opencmw::debug::resetStats();
+
+    constexpr std::array testCases = {
+        ""sv,
+        R"({ "id" : 42 ])"sv,
+        // R"({ "id" : 42)"sv, // TODO currently doesn't throw, ok or not?
+        R"(}{)"")"sv
+    };
+
+    for (const auto &testCase : testCases) {
+        opencmw::IoBuffer buffer;
+        std::cout << "Prepared json data: " << buffer.asString() << std::endl;
+        buffer.put<opencmw::IoBuffer::MetaInfo::WITHOUT>(testCase);
+        SimpleId foo;
+        REQUIRE_THROWS((opencmw::deserialise<opencmw::Json, opencmw::ProtocolCheck::ALWAYS>(buffer, foo)));
+    }
+}
+
 TEST_CASE("JsonDeserialisationMissingField", "[JsonSerialiser]") {
     opencmw::debug::resetStats();
     {


### PR DESCRIPTION
Before, deserialise would not terminate on "{ "id" : 42 ]".