### PR TITLE
CmwLight serialiser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,8 +24,7 @@ imgui.ini
 bin/
 build/
 out/
-cmake-build-debug/
-cmake-build-release/
+cmake-build-*/
 
 # Annoying OS Generated Files
 .DS_Store

--- a/concepts/serialiser/IoSerialiserBenchmark.cpp
+++ b/concepts/serialiser/IoSerialiserBenchmark.cpp
@@ -1,4 +1,5 @@
 #include "IoSerialiserBenchmark.hpp"
+#include <IoSerialiserCmwLight.hpp>
 #include <IoSerialiserJson.hpp>
 #include <IoSerialiserYAML.hpp>
 #include <IoSerialiserYaS.hpp>
@@ -17,13 +18,15 @@ using namespace opencmw::utils; // for operator<< and fmt::format overloading
  *
  * benchmark exemplary output:
  * [..]
- * IO Serializer (POCO, YaS, 0) throughput = 7.5 GB/s for 29.6 kB per test run (took 395.8 ms)
- * IO Serializer (POCO, YaS, 0) throughput = 7.5 GB/s for 29.6 kB per test run (took 397.1 ms)
- * IO Serializer (POCO, YaS, 0) throughput = 7.5 GB/s for 29.6 kB per test run (took 395.8 ms)
+ * IO Serializer (POCO, YaS, 0) throughput = 7.7 GB/s for 29.6 kB per test run (took 385.8 ms)
+ * IO Serializer (POCO, YaS, 0) throughput = 7.7 GB/s for 29.6 kB per test run (took 384.2 ms)
+ * [..]
+ * IO Serializer (POCO, CmwLight, 0) throughput = 9.3 GB/s for 29.0 kB per test run (took 312.3 ms)
  * ┌─protocol─┬────────ALWAYS─────────┬────────LENIENT────────┬────────IGNORE─────────┐
- * │   YAML   │ 95.7 MB/s ±   2.9 MB/s│ 99.4 MB/s ± 232.1 kB/s│ 86.5 MB/s ± 190.7 kB/s│
- * │   Json   │334.9 MB/s ± 780.6 kB/s│333.4 MB/s ± 560.1 kB/s│335.4 MB/s ± 822.2 kB/s│
- * │   YaS    │  6.9 GB/s ±   6.2 MB/s│  6.4 GB/s ±  73.3 MB/s│  7.5 GB/s ±  16.4 MB/s│
+ * │   YAML   │ 84.3 MB/s ±   8.1 MB/s│ 83.6 MB/s ± 427.6 kB/s│ 86.3 MB/s ± 539.8 kB/s│
+ * │   Json   │283.2 MB/s ±   1.6 MB/s│283.0 MB/s ±   1.8 MB/s│287.0 MB/s ± 854.8 kB/s│
+ * │   YaS    │  6.0 GB/s ±  33.0 MB/s│  6.3 GB/s ±  22.6 MB/s│  7.7 GB/s ±  47.9 MB/s│
+ * │ CmwLight │  8.0 GB/s ±  39.8 MB/s│  8.2 GB/s ±  24.9 MB/s│  9.3 GB/s ± 104.0 MB/s│
  * └──────────┴───────────────────────┴───────────────────────┴───────────────────────┘
  *
  */
@@ -72,6 +75,7 @@ int main() {
     results.emplace_back(runTests<YAML>(1'000));
     results.emplace_back(runTests<Json>(1'000));
     results.emplace_back(runTests<YaS>(100'000));
+    results.emplace_back(runTests<CmwLight>(100'000));
 
     constexpr int columWidth = 10;
     fmt::print("┌{2:─^{0}}┬{3:─^{1}}┬{4:─^{1}}┬{5:─^{1}}┐\n", columWidth, 2 * columWidth + 3, "protocol", "ALWAYS", "LENIENT", "IGNORE");

--- a/src/majordomo/include/majordomo/QuerySerialiser.hpp
+++ b/src/majordomo/include/majordomo/QuerySerialiser.hpp
@@ -13,15 +13,10 @@
 
 #include <charconv>
 #include <exception>
+#include <opencmw.hpp>
 #include <optional>
 #include <string_view>
 #include <unordered_map>
-
-// TODO move to opencmw.hpp?
-namespace opencmw {
-template<typename>
-constexpr bool always_false = false;
-}
 
 namespace opencmw::query {
 

--- a/src/serialiser/include/IoBuffer.hpp
+++ b/src/serialiser/include/IoBuffer.hpp
@@ -43,7 +43,7 @@ private:
                 _buffer = new uint8_t[_capacity];
             }
             // buffer already exists - copy existing content into newly allocated buffer N.B. maybe larger/smaller
-            uint8_t *tBuffer = new uint8_t[_capacity];
+            auto *tBuffer = new uint8_t[_capacity];
             // std::memmove(tBuffer, _buffer, std::min(_size, size) * sizeof(uint8_t));
             std::copy(_buffer, _buffer + std::min(_size, size) * sizeof(uint8_t), tBuffer);
             delete[] _buffer;
@@ -148,6 +148,16 @@ public:
     [[nodiscard]] forceinline constexpr uint8_t           *data() noexcept { return _buffer; }
     [[nodiscard]] forceinline constexpr const uint8_t     *data() const noexcept { return _buffer; }
     constexpr void                                         clear() noexcept { _position = _size = 0; }
+
+    template<bool checkRange = true>
+    forceinline constexpr void skip(int bytes) noexcept(!checkRange) {
+        if constexpr (checkRange) {
+            if (_position + static_cast<std::size_t>(bytes) > size()) { // catches both over and underflow
+                throw std::out_of_range(fmt::format("requested index {} is out-of-range [0,{}]", static_cast<std::ptrdiff_t>(_position) + bytes, _size));
+            }
+        }
+        _position += static_cast<std::size_t>(bytes);
+    }
 
     template<typename R, bool checkRange = true>
     forceinline constexpr R &at(const size_t &index) noexcept(!checkRange) {

--- a/src/serialiser/include/IoSerialiser.hpp
+++ b/src/serialiser/include/IoSerialiser.hpp
@@ -79,6 +79,7 @@ struct FieldDescriptionShort {
     uint64_t         headerStart       = 0U;
     std::size_t      dataStartPosition = 0U;
     std::size_t      dataEndPosition   = 0U;
+    int16_t          subfields         = 0;
     std::string_view fieldName;
     uint8_t          intDataType    = 0U;
     uint8_t          hierarchyDepth = 0;
@@ -88,6 +89,7 @@ struct FieldDescriptionLong {
     uint64_t         headerStart;
     std::size_t      dataStartPosition;
     std::size_t      dataEndPosition;
+    int16_t          subfields = 0;
     std::string_view fieldName;
     std::string_view unit;
     std::string_view description;
@@ -101,6 +103,7 @@ concept FieldDescription = requires(T v) {
     v.headerStart;
     v.dataStartPosition;
     v.dataEndPosition;
+    v.subfields;
     v.fieldName;
     v.intDataType;
     v.hierarchyDepth;
@@ -147,16 +150,32 @@ forceinline int32_t findMemberIndex(const std::string_view &fieldName) noexcept 
 
 namespace detail {
 
+template<ReflectableClass T>
+constexpr int16_t getNumberOfNonNullSubfields(const T &value) {
+    int16_t fields = 0;
+    for_each(refl::reflect(value).members, [&](const auto member, [[maybe_unused]] const auto index) {
+        if constexpr (is_field(member) && !is_static(member)) {
+            if constexpr (is_smart_pointer<std::remove_reference_t<decltype(member(value))>>) {
+                if (!member(value)) {
+                    return; // skip empty smart pointers
+                }
+            }
+            fields++;
+        }
+    });
+    return fields;
+}
+
 template<SerialiserProtocol protocol, const bool writeMetaInfo = true, typename DataType>
-constexpr auto newFieldHeader(const IoBuffer &buffer, const char *fieldName, const int hierarchyDepth = 0, const DataType &value = 0) {
+constexpr auto newFieldHeader(const IoBuffer &buffer, const char *fieldName, const int hierarchyDepth, const DataType &value, const int16_t subfields) {
     constexpr int typeID = IoSerialiser<protocol, std::remove_reference_t<decltype(getAnnotatedMember(unwrapPointer(value)))>>::getDataTypeId();
     const auto    pos    = buffer.size();
     if constexpr (writeMetaInfo && is_annotated<DataType>) {
-        return FieldDescriptionLong{ .headerStart = pos, .dataStartPosition = pos, .dataEndPosition = pos, .fieldName = fieldName, .unit = value.getUnit(), .description = value.getDescription(), .modifier = value.getModifier(), .intDataType = typeID, .hierarchyDepth = static_cast<uint8_t>(hierarchyDepth) };
+        return FieldDescriptionLong{ .headerStart = pos, .dataStartPosition = pos, .dataEndPosition = pos, .subfields = subfields, .fieldName = fieldName, .unit = value.getUnit(), .description = value.getDescription(), .modifier = value.getModifier(), .intDataType = typeID, .hierarchyDepth = static_cast<uint8_t>(hierarchyDepth) };
     } else if constexpr (writeMetaInfo) {
-        return FieldDescriptionLong{ .headerStart = pos, .dataStartPosition = pos, .dataEndPosition = pos, .fieldName = fieldName, .unit = "", .description = "", .modifier = RW, .intDataType = typeID, .hierarchyDepth = static_cast<uint8_t>(hierarchyDepth) };
+        return FieldDescriptionLong{ .headerStart = pos, .dataStartPosition = pos, .dataEndPosition = pos, .subfields = subfields, .fieldName = fieldName, .unit = "", .description = "", .modifier = RW, .intDataType = typeID, .hierarchyDepth = static_cast<uint8_t>(hierarchyDepth) };
     } else {
-        return FieldDescriptionShort{ .headerStart = pos, .dataStartPosition = pos, .dataEndPosition = pos, .fieldName = fieldName, .intDataType = typeID, .hierarchyDepth = static_cast<uint8_t>(hierarchyDepth) };
+        return FieldDescriptionShort{ .headerStart = pos, .dataStartPosition = pos, .dataEndPosition = pos, .subfields = subfields, .fieldName = fieldName, .intDataType = typeID, .hierarchyDepth = static_cast<uint8_t>(hierarchyDepth) };
     }
 }
 
@@ -173,7 +192,8 @@ constexpr void serialise(IoBuffer &buffer, ReflectableClass auto const &value, F
 
             using UnwrappedMemberType = std::remove_reference_t<decltype(getAnnotatedMember(unwrapPointer(fieldValue)))>;
             if constexpr (isReflectableClass<UnwrappedMemberType>()) { // nested data-structure
-                FieldDescription auto field                = newFieldHeader<protocol, writeMetaInfo>(buffer, member.name.c_str(), parent.hierarchyDepth + 1, fieldValue);
+                const auto            subfields            = getNumberOfNonNullSubfields(getAnnotatedMember(unwrapPointer(fieldValue)));
+                FieldDescription auto field                = newFieldHeader<protocol, writeMetaInfo>(buffer, member.name.c_str(), parent.hierarchyDepth + 1, FWD(fieldValue), subfields);
                 const std::size_t     posSizePositionStart = FieldHeaderWriter<protocol>::template put<writeMetaInfo>(buffer, field, START_MARKER_INST);
                 const std::size_t     posStartDataStart    = buffer.size();
                 serialise<protocol, writeMetaInfo>(buffer, getAnnotatedMember(unwrapPointer(fieldValue)), field); // do not inspect annotation itself
@@ -181,7 +201,7 @@ constexpr void serialise(IoBuffer &buffer, ReflectableClass auto const &value, F
                 updateSize<protocol>(buffer, posSizePositionStart, posStartDataStart);
                 return;
             } else { // field is a (possibly annotated) primitive type
-                FieldDescription auto field = newFieldHeader<protocol, writeMetaInfo>(buffer, member.name.c_str(), parent.hierarchyDepth + 1, fieldValue);
+                FieldDescription auto field = newFieldHeader<protocol, writeMetaInfo>(buffer, member.name.c_str(), parent.hierarchyDepth + 1, fieldValue, 0);
                 FieldHeaderWriter<protocol>::template put<writeMetaInfo>(buffer, field, fieldValue);
             }
         }
@@ -192,8 +212,8 @@ constexpr void serialise(IoBuffer &buffer, ReflectableClass auto const &value, F
 template<SerialiserProtocol protocol, const bool writeMetaInfo = true>
 constexpr void serialise(IoBuffer &buffer, ReflectableClass auto const &value) {
     putHeaderInfo<protocol>(buffer);
-    const auto       &reflectionData       = refl::reflect(value);
-    auto              field                = detail::newFieldHeader<protocol, writeMetaInfo>(buffer, reflectionData.name.c_str(), 0, reflectionData);
+    const auto        subfields            = detail::getNumberOfNonNullSubfields(value);
+    auto              field                = detail::newFieldHeader<protocol, writeMetaInfo>(buffer, refl::reflect(value).name.c_str(), 0, value, subfields);
     const std::size_t posSizePositionStart = FieldHeaderWriter<protocol>::template put<writeMetaInfo>(buffer, field, START_MARKER_INST);
     const std::size_t posStartDataStart    = buffer.size();
     detail::serialise<protocol, writeMetaInfo>(buffer, value, field);
@@ -247,7 +267,7 @@ constexpr void deserialise(IoBuffer &buffer, ReflectableClass auto &value, Deser
     }
 
     // read initial field header
-    auto field = newFieldHeader<protocol, true>(buffer, "", parent.hierarchyDepth, value);
+    auto field = newFieldHeader<protocol, true>(buffer, "", parent.hierarchyDepth, value, -1);
     FieldHeaderReader<protocol>::template get<check>(buffer, info, field);
     if (field.hierarchyDepth == 0 && field.fieldName != typeName<ValueType> && !field.fieldName.empty() && check != ProtocolCheck::IGNORE) { // check if root type is matching
         handleDeserialisationError<check>(info, "IoSerialiser<{}, {}>::deserialise: data is not of excepted type but of type {}", protocol::protocolName(), typeName<ValueType>, field.fieldName);
@@ -264,6 +284,7 @@ constexpr void deserialise(IoBuffer &buffer, ReflectableClass auto &value, Deser
     buffer.set_position(field.dataStartPosition); // skip to data start
 
     while (buffer.position() < buffer.size()) {
+        auto previousSubFields = field.subfields;
         FieldHeaderReader<protocol>::template get<check>(buffer, info, field);
         buffer.set_position(field.dataStartPosition); // skip to data start
 
@@ -298,34 +319,16 @@ constexpr void deserialise(IoBuffer &buffer, ReflectableClass auto &value, Deser
             continue;
         }
 
-        if (field.intDataType == IoSerialiser<protocol, START_MARKER>::getDataTypeId()) {
-            buffer.set_position(field.headerStart); // reset buffer position for the nested deserialiser to read again
-            // reached start of sub-structure -> dive in
-            for_each(refl::reflect<ValueType>().members, [&](auto member, int32_t index) {
-                if (index != fieldIndex) {
-                    return; // fieldName does not match -- skip to next field
-                }
-                using MemberType = std::remove_reference_t<decltype(getAnnotatedMember(unwrapPointer(member(value))))>;
-                if constexpr (isReflectableClass<MemberType>()) {
-                    field.hierarchyDepth++;
-                    field.fieldName = member.name.c_str(); // N.B. needed since member.name is referring to compile-time const string
-                    deserialise<protocol, check>(buffer, unwrapPointerCreateIfAbsent(member(value)), info, field);
-                    field.hierarchyDepth--;
-                    if constexpr (check != ProtocolCheck::IGNORE) {
-                        info.setFields[parent.fieldName][static_cast<uint64_t>(fieldIndex)] = true;
-                    }
-                }
-            });
-        }
-
         for_each(refl::reflect<ValueType>().members, [&](auto member, int32_t memberIndex) {
             if constexpr (!is_field(member) || is_static(member)) return;
             if (memberIndex != fieldIndex) return; // fieldName does not match -- skip to next field
 
             using MemberType = std::remove_reference_t<decltype(getAnnotatedMember(unwrapPointer(member(value))))>;
-            if constexpr (isReflectableClass<MemberType>() || !is_writable(member) || is_static(member)) {
+            if constexpr (!is_writable(member) || is_static(member)) {
                 moveToFieldEndBufferPosition(buffer, field);
                 return;
+            } else if constexpr (isReflectableClass<MemberType>()) {
+                field.intDataType = IoSerialiser<protocol, START_MARKER>::getDataTypeId();
             } else {
                 constexpr int requestedType = IoSerialiser<protocol, MemberType>::getDataTypeId();
                 if (requestedType != field.intDataType) { // mismatching data-type
@@ -362,6 +365,27 @@ constexpr void deserialise(IoBuffer &buffer, ReflectableClass auto &value, Deser
             }
         });
 
+        if (field.intDataType == IoSerialiser<protocol, START_MARKER>::getDataTypeId()) {
+            buffer.set_position(field.headerStart); // reset buffer position for the nested deserialiser to read again
+            // reached start of sub-structure -> dive in
+            for_each(refl::reflect<ValueType>().members, [&](auto member, int32_t index) {
+                if (index != fieldIndex) {
+                    return; // fieldName does not match -- skip to next field
+                }
+                using MemberType = std::remove_reference_t<decltype(getAnnotatedMember(unwrapPointer(member(value))))>;
+                if constexpr (isReflectableClass<MemberType>()) {
+                    field.hierarchyDepth++;
+                    field.fieldName = member.name.c_str(); // N.B. needed since member.name is referring to compile-time const string
+                    deserialise<protocol, check>(buffer, unwrapPointerCreateIfAbsent(member(value)), info, field);
+                    field.hierarchyDepth--;
+                    if constexpr (check != ProtocolCheck::IGNORE) {
+                        info.setFields[parent.fieldName][static_cast<uint64_t>(fieldIndex)] = true;
+                    }
+                }
+            });
+            field.subfields = previousSubFields - 1;
+        }
+
         // skip to data end if field header defines the end
         if (field.dataEndPosition != std::numeric_limits<size_t>::max() && field.dataEndPosition != buffer.position()) {
             if (check != ProtocolCheck::IGNORE) {
@@ -388,7 +412,7 @@ DeserialiserInfo deserialise(IoBuffer &buffer, ReflectableClass auto &value, Des
     if (check == ProtocolCheck::LENIENT && !info.exceptions.empty()) {
         return info; // do not attempt to deserialise data with wrong header
     }
-    FieldDescription auto fieldDescription = detail::newFieldHeader<protocol, true>(buffer, detail::ROOT_NAME, 0, value);
+    FieldDescription auto fieldDescription = detail::newFieldHeader<protocol, true>(buffer, detail::ROOT_NAME, 0, value, -1);
     detail::deserialise<protocol, check>(buffer, value, info, fieldDescription);
     return info;
 }

--- a/src/serialiser/include/IoSerialiserCmwLight.hpp
+++ b/src/serialiser/include/IoSerialiserCmwLight.hpp
@@ -2,37 +2,319 @@
 #define OPENCMW_CMWLIGHTSERIALISER_H
 
 #include "IoSerialiser.hpp"
-#include <list>
-#include <map>
-#include <queue>
+#include <string_view>
 
 #pragma clang diagnostic push
 #pragma ide diagnostic   ignored "cppcoreguidelines-avoid-magic-numbers"
 #pragma ide diagnostic   ignored "cppcoreguidelines-avoid-c-arrays"
 
 namespace opencmw {
+
 struct CmwLight : Protocol<"CmwLight"> {
 };
 
 namespace cmwlight {
 
+void skipString(IoBuffer &buffer);
+
+template<typename T>
+inline void skipArray(IoBuffer &buffer) {
+    if constexpr (is_stringlike<T>) {
+        for (auto i = buffer.get<int32_t>(); i > 0; i--) {
+            skipString(buffer);
+        }
+    } else {
+        buffer.skip(buffer.get<int32_t>() * static_cast<int32_t>(sizeof(T)));
+    }
 }
 
+inline void skipString(IoBuffer &buffer) { skipArray<char>(buffer); }
+
+template<typename T>
+inline void skipMultiArray(IoBuffer &buffer) {
+    buffer.skip(buffer.get<int32_t>() * static_cast<int32_t>(sizeof(int32_t))); // skip size header
+    skipArray<T>(buffer);                                                       // skip elements
+}
+
+template<typename T>
+inline int getTypeId() {
+    return IoSerialiser<CmwLight, T>::getDataTypeId();
+}
+template<typename T>
+inline int getTypeIdVector() {
+    return IoSerialiser<CmwLight, std::vector<T>>::getDataTypeId();
+}
+template<typename T, size_t N>
+inline int getTypeIdMultiArray() {
+    return IoSerialiser<CmwLight, MultiArray<T, N>>::getDataTypeId();
+}
+
+} // namespace cmwlight
+
+template<typename T>
+struct IoSerialiser<CmwLight, T> {
+    inline static constexpr uint8_t getDataTypeId() { return 0xFF; } // default value
+};
+
 template<Number T>
-struct IoSerialiser<T, CmwLight> { // catch all template
-    constexpr static bool serialise(IoBuffer &buffer, FieldDescription auto &field, const T &value) noexcept {
-        if (std::is_constant_evaluated()) {
-            using namespace std::literals;
-            buffer.put(field);
-            buffer.template put(value);
-            return true;
-        }
-        std::cout << fmt::format("{} - serialise-catch-all: {} {} value: {} - constexpr?: {}\n",
-                CmwLight::protocolName(), typeName<T>, field.fieldName, value,
-                std::is_constant_evaluated());
-        return false;
+struct IoSerialiser<CmwLight, T> {
+    inline static constexpr uint8_t getDataTypeId() {
+        // clang-format off
+        if      constexpr (std::is_same_v<bool   , T>) { return 0; }
+        else if constexpr (std::is_same_v<int8_t , T>) { return 1; }
+        else if constexpr (std::is_same_v<int16_t, T>) { return 2; }
+        else if constexpr (std::is_same_v<int32_t, T>) { return 3; }
+        else if constexpr (std::is_same_v<int64_t, T>) { return 4; }
+        else if constexpr (std::is_same_v<float  , T>) { return 5; }
+        else if constexpr (std::is_same_v<double , T>) { return 6; }
+        else if constexpr (std::is_same_v<char   , T>) { return 201; }
+        else { static_assert(opencmw::always_false<T>); }
+        // clang-format on
+    }
+
+    constexpr static void serialise(IoBuffer &buffer, FieldDescription auto const & /*field*/, const T &value) noexcept {
+        buffer.put(value);
+    }
+
+    constexpr static void deserialise(IoBuffer &buffer, FieldDescription auto const & /*field*/, T &value) noexcept {
+        value = buffer.get<T>();
     }
 };
+
+template<StringLike T>
+struct IoSerialiser<CmwLight, T> {
+    inline static constexpr uint8_t getDataTypeId() { return 7; }
+
+    constexpr static void           serialise(IoBuffer &buffer, FieldDescription auto const           &/*field*/, const T &value) noexcept {
+        buffer.put(value);
+    }
+
+    constexpr static void deserialise(IoBuffer &buffer, FieldDescription auto const & /*field*/, T &value) noexcept {
+        value = buffer.get<T>();
+    }
+};
+
+template<ArrayOrVector T>
+struct IoSerialiser<CmwLight, T> {
+    using MemberType = typename T::value_type;
+
+    inline static constexpr uint8_t getDataTypeId() {
+        // clang-format off
+        if      constexpr (std::is_same_v<bool   , MemberType>) { return  9; }
+        else if constexpr (std::is_same_v<int8_t , MemberType>) { return 10; }
+        else if constexpr (std::is_same_v<int16_t, MemberType>) { return 11; }
+        else if constexpr (std::is_same_v<int32_t, MemberType>) { return 12; }
+        else if constexpr (std::is_same_v<int64_t, MemberType>) { return 13; }
+        else if constexpr (std::is_same_v<float  , MemberType>) { return 14; }
+        else if constexpr (std::is_same_v<double , MemberType>) { return 15; }
+        else if constexpr (std::is_same_v<char   , MemberType>) { return 202; }
+        else if constexpr (opencmw::is_stringlike<MemberType> ) { return 16; }
+        else { static_assert(opencmw::always_false<T>); }
+        // clang-format on
+    }
+
+    constexpr static void serialise(IoBuffer &buffer, FieldDescription auto const & /*field*/, const T &value) noexcept {
+        buffer.put(value);
+    }
+
+    constexpr static void deserialise(IoBuffer &buffer, FieldDescription auto const & /*field*/, T &value) noexcept {
+        buffer.getArray(value);
+    }
+};
+
+template<MultiArrayType T>
+struct IoSerialiser<CmwLight, T> {
+    inline static constexpr uint8_t getDataTypeId() {
+        // clang-format off
+        if      constexpr (std::is_same_v<bool   , typename T::value_type> && T::n_dims_ == 1) { return cmwlight::getTypeIdVector<typename T::value_type>(); }
+        else if constexpr (std::is_same_v<int8_t , typename T::value_type> && T::n_dims_ == 1) { return cmwlight::getTypeIdVector<typename T::value_type>(); }
+        else if constexpr (std::is_same_v<int16_t, typename T::value_type> && T::n_dims_ == 1) { return cmwlight::getTypeIdVector<typename T::value_type>(); }
+        else if constexpr (std::is_same_v<int32_t, typename T::value_type> && T::n_dims_ == 1) { return cmwlight::getTypeIdVector<typename T::value_type>(); }
+        else if constexpr (std::is_same_v<int64_t, typename T::value_type> && T::n_dims_ == 1) { return cmwlight::getTypeIdVector<typename T::value_type>(); }
+        else if constexpr (std::is_same_v<float  , typename T::value_type> && T::n_dims_ == 1) { return cmwlight::getTypeIdVector<typename T::value_type>(); }
+        else if constexpr (std::is_same_v<double , typename T::value_type> && T::n_dims_ == 1) { return cmwlight::getTypeIdVector<typename T::value_type>(); }
+        else if constexpr (std::is_same_v<char   , typename T::value_type> && T::n_dims_ == 1) { return cmwlight::getTypeIdVector<typename T::value_type>(); }
+        else if constexpr (opencmw::is_stringlike<typename T::value_type>  && T::n_dims_ == 1) { return cmwlight::getTypeIdVector<typename T::value_type>(); }
+        else if constexpr (std::is_same_v<bool   , typename T::value_type> && T::n_dims_ == 2) { return 17; }
+        else if constexpr (std::is_same_v<int8_t , typename T::value_type> && T::n_dims_ == 2) { return 18; }
+        else if constexpr (std::is_same_v<int16_t, typename T::value_type> && T::n_dims_ == 2) { return 19; }
+        else if constexpr (std::is_same_v<int32_t, typename T::value_type> && T::n_dims_ == 2) { return 20; }
+        else if constexpr (std::is_same_v<int64_t, typename T::value_type> && T::n_dims_ == 2) { return 21; }
+        else if constexpr (std::is_same_v<float  , typename T::value_type> && T::n_dims_ == 2) { return 22; }
+        else if constexpr (std::is_same_v<double , typename T::value_type> && T::n_dims_ == 2) { return 23; }
+        else if constexpr (std::is_same_v<char   , typename T::value_type> && T::n_dims_ == 2) { return 203; }
+        else if constexpr (opencmw::is_stringlike<typename T::value_type>  && T::n_dims_ == 2) { return 24; }
+        else if constexpr (std::is_same_v<bool   , typename T::value_type>) { return 25; }
+        else if constexpr (std::is_same_v<int8_t , typename T::value_type>) { return 26; }
+        else if constexpr (std::is_same_v<int16_t, typename T::value_type>) { return 27; }
+        else if constexpr (std::is_same_v<int32_t, typename T::value_type>) { return 28; }
+        else if constexpr (std::is_same_v<int64_t, typename T::value_type>) { return 29; }
+        else if constexpr (std::is_same_v<float  , typename T::value_type>) { return 30; }
+        else if constexpr (std::is_same_v<double , typename T::value_type>) { return 31; }
+        else if constexpr (std::is_same_v<char   , typename T::value_type>) { return 204; }
+        else if constexpr (opencmw::is_stringlike<typename T::value_type> ) { return 32; }
+        else { static_assert(opencmw::always_false<T>); }
+        // clang-format on
+    }
+
+    constexpr static void serialise(IoBuffer &buffer, FieldDescription auto const & /*field*/, const T &value) noexcept {
+        std::array<int32_t, T::n_dims_> dims;
+        for (uint32_t i = 0U; i < T::n_dims_; i++) {
+            dims[i] = static_cast<int32_t>(value.dimensions()[i]);
+        }
+        buffer.put(dims);
+        buffer.put(value.elements()); // todo: account for strides and offsets (possibly use iterators?)
+    }
+
+    constexpr static void deserialise(IoBuffer &buffer, FieldDescription auto const & /*field*/, T &value) noexcept {
+        const std::array<int32_t, T::n_dims_> dimWire = buffer.getArray<int32_t, T::n_dims_>();
+        for (auto i = 0U; i < T::n_dims_; i++) {
+            value.dimensions()[i] = static_cast<typename T::size_t_>(dimWire[i]);
+        }
+        value.element_count()        = value.dimensions()[T::n_dims_ - 1];
+        value.stride(T::n_dims_ - 1) = 1;
+        value.offset(T::n_dims_ - 1) = 0;
+        for (auto i = T::n_dims_ - 1; i > 0; i--) {
+            value.element_count() *= value.dimensions()[i - 1];
+            value.stride(i - 1) = value.stride(i) * value.dimensions()[i];
+            value.offset(i - 1) = 0;
+        }
+        buffer.getArray(value.elements());
+    }
+};
+
+template<>
+struct IoSerialiser<CmwLight, START_MARKER> {
+    inline static constexpr uint8_t getDataTypeId() { return 0xFC; }
+
+    constexpr static void           serialise(IoBuffer &buffer, FieldDescription auto const &field, const START_MARKER           &/*value*/) noexcept {
+        buffer.put(static_cast<int32_t>(field.subfields));
+    }
+
+    constexpr static void deserialise(IoBuffer & /*buffer*/, FieldDescription auto const & /*field*/, const START_MARKER &) {
+        // do not do anything, as the start marker is of size zero and only the type byte is important
+    }
+};
+
+template<>
+struct IoSerialiser<CmwLight, END_MARKER> {
+    inline static constexpr uint8_t getDataTypeId() { return 0xFE; }
+
+    static void                     serialise(IoBuffer                     &/*buffer*/, FieldDescription auto const                     &/*field*/, const END_MARKER                     &/*value*/) noexcept {
+        // do not do anything, as the end marker is of size zero and only the type byte is important
+    }
+
+    constexpr static void deserialise(IoBuffer & /*buffer*/, FieldDescription auto const & /*field*/, const END_MARKER &) {
+        // do not do anything, as the end marker is of size zero and only the type byte is important
+    }
+};
+
+template<>
+struct IoSerialiser<CmwLight, OTHER> {
+    inline static constexpr uint8_t getDataTypeId() { return 0xFD; }
+
+    static void                     serialise(IoBuffer                     &/*buffer*/, FieldDescription auto const                     &/*field*/, const END_MARKER                     &/*value*/) noexcept {
+        // do not do anything, as the end marker is of size zero and only the type byte is important
+    }
+
+    static void deserialise(IoBuffer &buffer, FieldDescription auto const &field, const OTHER &) {
+        using namespace cmwlight;
+        auto typeId = field.intDataType;
+        // clang-format off
+        // primitives
+             if (typeId == getTypeId<bool       >()) { buffer.skip(sizeof(bool   )); }
+        else if (typeId == getTypeId<int8_t     >()) { buffer.skip(sizeof(int8_t )); }
+        else if (typeId == getTypeId<int16_t    >()) { buffer.skip(sizeof(int16_t)); }
+        else if (typeId == getTypeId<int32_t    >()) { buffer.skip(sizeof(int32_t)); }
+        else if (typeId == getTypeId<int64_t    >()) { buffer.skip(sizeof(int64_t)); }
+        else if (typeId == getTypeId<float      >()) { buffer.skip(sizeof(float  )); }
+        else if (typeId == getTypeId<double     >()) { buffer.skip(sizeof(double )); }
+        else if (typeId == getTypeId<char       >()) { buffer.skip(sizeof(char   )); }
+        else if (typeId == getTypeId<std::string>()) { skipString(buffer); }
+        // arrays
+        else if (typeId == getTypeIdVector<int8_t     >()) { skipArray<int8_t     >(buffer); }
+        else if (typeId == getTypeIdVector<int16_t    >()) { skipArray<int16_t    >(buffer); }
+        else if (typeId == getTypeIdVector<int32_t    >()) { skipArray<int32_t    >(buffer); }
+        else if (typeId == getTypeIdVector<int64_t    >()) { skipArray<int64_t    >(buffer); }
+        else if (typeId == getTypeIdVector<float      >()) { skipArray<float      >(buffer); }
+        else if (typeId == getTypeIdVector<double     >()) { skipArray<double     >(buffer); }
+        else if (typeId == getTypeIdVector<char       >()) { skipArray<char       >(buffer); }
+        else if (typeId == getTypeIdVector<std::string>()) { skipArray<std::string>(buffer); }
+        // 2D and Multi array
+        else if (typeId == getTypeIdMultiArray<int8_t     , 2>() || typeId == getTypeIdMultiArray<int8_t     , 3>()) { skipMultiArray<int8_t     >(buffer); }
+        else if (typeId == getTypeIdMultiArray<int16_t    , 2>() || typeId == getTypeIdMultiArray<int16_t    , 3>()) { skipMultiArray<int16_t    >(buffer); }
+        else if (typeId == getTypeIdMultiArray<int32_t    , 2>() || typeId == getTypeIdMultiArray<int32_t    , 3>()) { skipMultiArray<int32_t    >(buffer); }
+        else if (typeId == getTypeIdMultiArray<int64_t    , 2>() || typeId == getTypeIdMultiArray<int64_t    , 3>()) { skipMultiArray<int64_t    >(buffer); }
+        else if (typeId == getTypeIdMultiArray<float      , 2>() || typeId == getTypeIdMultiArray<float      , 3>()) { skipMultiArray<float      >(buffer); }
+        else if (typeId == getTypeIdMultiArray<double     , 2>() || typeId == getTypeIdMultiArray<double     , 3>()) { skipMultiArray<double     >(buffer); }
+        else if (typeId == getTypeIdMultiArray<char       , 2>() || typeId == getTypeIdMultiArray<char       , 3>()) { skipMultiArray<char       >(buffer); }
+        else if (typeId == getTypeIdMultiArray<std::string, 2>() || typeId == getTypeIdMultiArray<std::string, 3>()) { skipMultiArray<std::string>(buffer); }
+        // nested
+        // unsupported
+        else { throw ProtocolException(fmt::format("Skipping data type {} is not supported", typeId)); }
+        // clang-format on
+    }
+};
+
+template<>
+struct FieldHeaderWriter<CmwLight> {
+    template<const bool /*writeMetaInfo*/, typename DataType>
+    constexpr std::size_t static put(IoBuffer &buffer, FieldDescription auto const &field, const DataType &data) {
+        using StrippedDataType = std::remove_reference_t<decltype(getAnnotatedMember(unwrapPointer(data)))>;
+        if constexpr (is_same_v<DataType, END_MARKER>) { // do not put endMarker type id into buffer
+            return std::numeric_limits<size_t>::max();
+        }
+        constexpr auto dataTypeSize = static_cast<int32_t>(sizeof(StrippedDataType));
+        buffer.reserve_spare(((field.fieldName.size() + 2UL) * sizeof(uint8_t)) + dataTypeSize);
+        if (field.hierarchyDepth != 0) {
+            buffer.put<IoBuffer::MetaInfo::WITH>(field.fieldName); // full field name with zero termination
+        }
+        if constexpr (!is_same_v<DataType, START_MARKER>) {                        // do not put startMarker type id into buffer
+            buffer.put(IoSerialiser<CmwLight, StrippedDataType>::getDataTypeId()); // data type ID
+        }
+        IoSerialiser<CmwLight, StrippedDataType>::serialise(buffer, field, getAnnotatedMember(unwrapPointer(data)));
+        return std::numeric_limits<size_t>::max();
+    }
+};
+
+template<>
+struct FieldHeaderReader<CmwLight> {
+    template<ProtocolCheck protocolCheckVariant>
+    inline static void get(IoBuffer &buffer, DeserialiserInfo & /*info*/, FieldDescription auto &field) {
+        field.headerStart     = buffer.position();
+        field.dataEndPosition = std::numeric_limits<size_t>::max();
+        field.modifier        = ExternalModifier::UNKNOWN;
+        if (field.subfields == 0) {
+            field.intDataType = IoSerialiser<CmwLight, END_MARKER>::getDataTypeId();
+            field.hierarchyDepth--;
+            field.dataStartPosition = buffer.position();
+            return;
+        }
+        if (field.subfields == -1) {
+            if (field.hierarchyDepth != 0) {                      // do not read field description for root element
+                field.fieldName = buffer.get<std::string_view>(); // full field name
+            }
+            field.intDataType = IoSerialiser<CmwLight, START_MARKER>::getDataTypeId();
+            field.subfields   = static_cast<int16_t>(buffer.get<int32_t>());
+        } else {
+            field.fieldName   = buffer.get<std::string_view>(); // full field name
+            field.intDataType = buffer.get<uint8_t>();          // data type ID
+            field.subfields--;                                  // decrease the number of remaining fields in the structure... todo: adapt strategy for nested fields (has to somewhere store subfields)
+        }
+        field.dataStartPosition = buffer.position();
+    }
+};
+
+template<>
+inline DeserialiserInfo checkHeaderInfo<CmwLight>(IoBuffer &buffer, DeserialiserInfo info, const ProtocolCheck /*protocolCheckVariant*/) {
+    // cmw has no specific header to check, we could try to find a common pattern in all cmw output to match to that
+    // minimal thing to do is to check the number of fields to be non-zero. N.B. this fails for YaS data
+    if (buffer.at<int32_t>(buffer.position()) == 0) {
+        throw ProtocolException("Illegal number of members"); // todo: respect protocol check type
+    }
+    return info;
+}
+
 } // namespace opencmw
 
 #pragma clang diagnostic pop

--- a/src/serialiser/include/IoSerialiserYAML.hpp
+++ b/src/serialiser/include/IoSerialiserYAML.hpp
@@ -32,7 +32,7 @@ constexpr void addSpace(IoBuffer &buffer, const uint8_t hierarchyDepth, const ui
     int            count        = 0;
     constexpr auto isWhiteSpace = [](uint8_t c) noexcept { return c == ' ' || c == '\t' || c == '\r'; };
     while (buffer.position() < buffer.size() && isWhiteSpace(buffer.at<uint8_t>(buffer.position()))) {
-        buffer.set_position(buffer.position() + 1);
+        buffer.skip<false>(1);
         count++;
     }
     return count;
@@ -44,10 +44,10 @@ constexpr void addSpace(IoBuffer &buffer, const uint8_t hierarchyDepth, const ui
     }
     const auto start = buffer.position();
     while (buffer.position() < buffer.size() && buffer.at<char>(buffer.position()) != '\n') {
-        buffer.set_position(buffer.position() + 1);
+        buffer.skip<false>(1);
     }
     if (buffer.at<char>(buffer.position()) == '\n') {
-        buffer.set_position(buffer.position() + 1);
+        buffer.skip<false>(1);
     }
     return static_cast<int>(buffer.position() - start);
 }
@@ -348,10 +348,9 @@ inline DeserialiserInfo checkHeaderInfo<YAML>(IoBuffer &buffer, DeserialiserInfo
             throw ProtocolException("YAML: buffer too small or missing (`---') line: '{}' pos: {}  size: {}", line, position, buffer.size());
         }
     }
-    buffer.set_position(position + 3);
+    buffer.skip<false>(3);
     [[maybe_unused]] const auto nWhitespaces = static_cast<std::size_t>(yaml::detail::consumeWhitespace(buffer));
     [[maybe_unused]] const auto nTillEnd     = static_cast<std::size_t>(yaml::detail::moveToEndOfLine(buffer));
-    buffer.set_position(position + 3 + nWhitespaces + nTillEnd); // move to next line
     if (nTillEnd > 1 || buffer.at<uint8_t>(buffer.position() - 1) != '\n') {
         if (check == ProtocolCheck::LENIENT) {
             info.exceptions.emplace_back("YAML: non-white-space characters after (`---') line: '{}' pos: {}  size: {}", line, position, buffer.size());

--- a/src/serialiser/include/IoSerialiserYaS.hpp
+++ b/src/serialiser/include/IoSerialiserYaS.hpp
@@ -127,7 +127,7 @@ struct IoSerialiser<YaS, T> {
         for (auto i = 0U; i < T::n_dims_; i++) {
             value.dimensions()[i] = static_cast<typename T::size_t_>(dimWire[i]);
         }
-        value.element_count()        = value.dimensions()[T::n_dims_];
+        value.element_count()        = value.dimensions()[T::n_dims_ - 1];
         value.stride(T::n_dims_ - 1) = 1;
         value.offset(T::n_dims_ - 1) = 0;
         for (auto i = T::n_dims_ - 1; i > 0; i--) {

--- a/src/serialiser/include/opencmw.hpp
+++ b/src/serialiser/include/opencmw.hpp
@@ -30,6 +30,9 @@ inline constexpr const bool is_quantity<T> = true;
 } // namespace units::detail
 
 namespace opencmw {
+template<typename>
+constexpr bool always_false = false;
+
 using units::basic_fixed_string;
 using units::is_same_v;
 

--- a/src/serialiser/include/opencmw.hpp
+++ b/src/serialiser/include/opencmw.hpp
@@ -48,6 +48,8 @@ inline constexpr bool isReflectableClass() {
     }
     return false;
 }
+template<typename T>
+constexpr bool isReflectableClass_v = isReflectableClass<T>();
 template<class T>
 concept ReflectableClass = isReflectableClass<T>();
 

--- a/src/serialiser/test/CMakeLists.txt
+++ b/src/serialiser/test/CMakeLists.txt
@@ -1,6 +1,6 @@
 include(CTest)
 include(Catch)
-add_executable(serialiser_tests catch_main.cpp IoBuffer_tests.cpp IoSerialiserYaS_tests.cpp IoSerialiserJson_tests.cpp MultiArray_tests.cpp Utils_tests.cpp IoSerialiserYAML_tests.cpp 00_opencmw_basic_tests.cpp)
+add_executable(serialiser_tests catch_main.cpp IoBuffer_tests.cpp IoSerialiserYaS_tests.cpp IoSerialiserJson_tests.cpp IoSerialiserCmwLight_tests.cpp MultiArray_tests.cpp Utils_tests.cpp IoSerialiserYAML_tests.cpp 00_opencmw_basic_tests.cpp)
 target_link_libraries(serialiser_tests PUBLIC project_warnings project_options CONAN_PKG::catch2 serialiser)
 # automatically discover tests that are defined in catch based test files you can modify the unittests. Set TEST_PREFIX to whatever you want, or use different for different binaries
 # catch_discover_tests(serialiser_tests TEST_PREFIX  "unittests." REPORTER xml OUTPUT_DIR . OUTPUT_PREFIX "unittests." OUTPUT_SUFFIX .xml)

--- a/src/serialiser/test/IoBuffer_tests.cpp
+++ b/src/serialiser/test/IoBuffer_tests.cpp
@@ -329,4 +329,24 @@ TEST_CASE("IoBuffer syntax - arrays", "[IoBuffer]") {
     opencmw::debug::resetStats();
 }
 
+TEST_CASE("IoBuffer syntax - navigation", "[IoBuffer]") {
+    opencmw::debug::resetStats();
+    {
+        opencmw::debug::Timer timer("IoBuffer syntax -array", 30);
+        opencmw::IoBuffer     buffer;
+
+        buffer.put(std::vector<int>{ 1, 2, 3, 4, 5 }); // put some data into the buffer
+        REQUIRE(buffer.position() == 0);
+        buffer.skip(24);
+        REQUIRE(buffer.position() == 24);
+        REQUIRE_THROWS_AS(buffer.skip(5), std::out_of_range);
+        REQUIRE_THROWS_AS(buffer.skip(-25), std::out_of_range);
+        buffer.skip(-24);
+        REQUIRE(buffer.position() == 0);
+        buffer.skip(10);
+        REQUIRE(buffer.position() == 10);
+    }
+    REQUIRE(opencmw::debug::alloc == opencmw::debug::dealloc); // a memory leak occurred
+    opencmw::debug::resetStats();
+}
 #pragma clang diagnostic pop

--- a/src/serialiser/test/IoSerialiserCmwLight_tests.cpp
+++ b/src/serialiser/test/IoSerialiserCmwLight_tests.cpp
@@ -1,0 +1,169 @@
+#pragma clang diagnostic push
+#pragma ide diagnostic   ignored "LoopDoesntUseConditionVariableInspection"
+#pragma ide diagnostic   ignored "cppcoreguidelines-avoid-magic-numbers"
+
+#include <catch2/catch.hpp>
+#include <Debug.hpp>
+#include <IoSerialiserCmwLight.hpp>
+#include <iostream>
+#include <string_view>
+#include <Utils.hpp>
+
+using namespace std::literals;
+
+using opencmw::Annotated;
+using opencmw::NoUnit;
+using opencmw::ProtocolCheck;
+using opencmw::ExternalModifier::RO;
+using opencmw::ExternalModifier::RW;
+using opencmw::ExternalModifier::RW_DEPRECATED;
+using opencmw::ExternalModifier::RW_PRIVATE;
+
+namespace ioserialiser_cmwlight_test {
+struct SimpleTestData {
+    int                             a   = 1337;
+    float                           ab  = 13.37f;
+    double                          abc = 42.23;
+    std::string                     b   = "hello";
+    std::array<int, 3>              c{ 3, 2, 1 };
+    std::vector<double>             cd{ 2.3, 3.4, 4.5, 5.6 };
+    std::vector<std::string>        ce{ "hello", "world" };
+    opencmw::MultiArray<double, 2>  d{ { 1, 2, 3, 4, 5, 6 }, { 2, 3 } };
+    std::unique_ptr<SimpleTestData> e = nullptr;
+    bool                            operator==(const ioserialiser_cmwlight_test::SimpleTestData &other) const { // deep comparison function
+        return a == other.a && ab == other.ab && abc == other.abc && b == other.b && c == other.c && cd == other.cd && d == other.d && ((!e && !other.e) || *e == *(other.e));
+    }
+};
+} // namespace ioserialiser_cmwlight_test
+ENABLE_REFLECTION_FOR(ioserialiser_cmwlight_test::SimpleTestData, a, ab, abc, b, c, cd, ce, d, e)
+
+TEST_CASE("IoClassSerialiserCmwLight simple test", "[IoClassSerialiser]") {
+    using namespace opencmw;
+    using namespace opencmw::utils; // for operator<< and fmt::format overloading
+    using namespace ioserialiser_cmwlight_test;
+    debug::resetStats();
+    {
+        debug::Timer timer("IoClassSerialiser basic syntax", 30);
+
+        IoBuffer     buffer;
+        std::cout << fmt::format("buffer size (before): {} bytes\n", buffer.size());
+
+        SimpleTestData data{
+            .a   = 30,
+            .ab  = 1.2f,
+            .abc = 1.23,
+            .b   = "abc",
+            .c   = { 5, 4, 3 },
+            .cd  = { 2.1, 4.2 },
+            .ce  = { "hallo", "welt" },
+            .d   = { { 6, 5, 4, 3, 2, 1 }, { 3, 2 } },
+            .e   = std::make_unique<SimpleTestData>(SimpleTestData{
+                      .a   = 40,
+                      .ab  = 2.2f,
+                      .abc = 2.23,
+                      .b   = "abcdef",
+                      .c   = { 9, 8, 7 },
+                      .cd  = { 3.1, 1.2 },
+                      .ce  = { "ei", "gude" },
+                      .d   = { { 6, 5, 4, 3, 2, 1 }, { 3, 2 } },
+                      .e   = nullptr })
+        };
+
+        // check that empty buffer cannot be deserialised
+        buffer.put(0L);
+        CHECK_THROWS_AS((opencmw::deserialise<opencmw::CmwLight, ProtocolCheck::LENIENT>(buffer, data)), ProtocolException);
+        buffer.clear();
+
+        SimpleTestData data2;
+        REQUIRE(data != data2);
+        std::cout << "object (short): " << ClassInfoShort << data << '\n';
+        std::cout << fmt::format("object (fmt): {}\n", data);
+        std::cout << "object (long):  " << ClassInfoVerbose << data << '\n';
+
+        opencmw::serialise<opencmw::CmwLight>(buffer, data);
+        std::cout << fmt::format("buffer size (after): {} bytes\n", buffer.size());
+
+        buffer.put("a\0df"sv); // add some garbage after the serialised object to check if it is handled correctly
+
+        buffer.reset();
+        auto result = opencmw::deserialise<opencmw::CmwLight, ProtocolCheck::LENIENT>(buffer, data2);
+        std::cout << "deserialised object (long):  " << ClassInfoVerbose << data2 << '\n';
+        std::cout << "deserialisation messages: " << result << std::endl;
+        REQUIRE(data == data2);
+    }
+    REQUIRE(opencmw::debug::dealloc == opencmw::debug::alloc); // a memory leak occurred
+    debug::resetStats();
+}
+
+namespace ioserialiser_cmwlight_test {
+struct SimpleTestDataMoreFields {
+    int                             a2   = 1336;
+    float                           ab2  = 13.36f;
+    double                          abc2 = 42.22;
+    std::string                     b2   = "bonjour";
+    std::array<int, 3>              c2{ 7, 8, 9 };
+    std::vector<double>             cd2{ 2.4, 3.6, 4.8, 5.0 };
+    std::vector<std::string>        ce2{ "hello", "world" };
+    opencmw::MultiArray<double, 2>  d2{ { 4, 5, 6, 7, 8, 9 }, { 2, 3 } };
+    std::unique_ptr<SimpleTestData> e2  = nullptr;
+    int                             a   = 1337;
+    float                           ab  = 13.37f;
+    double                          abc = 42.23;
+    std::string                     b   = "hello";
+    std::array<int, 3>              c{ 3, 2, 1 };
+    std::vector<double>             cd{ 2.3, 3.4, 4.5, 5.6 };
+    std::vector<std::string>        ce{ "hello", "world" };
+    opencmw::MultiArray<double, 2>  d{ { 1, 2, 3, 4, 5, 6 }, { 2, 3 } };
+    bool                            operator==(const SimpleTestDataMoreFields &) const = default;
+    std::unique_ptr<SimpleTestData> e                                                  = nullptr;
+};
+} // namespace ioserialiser_cmwlight_test
+ENABLE_REFLECTION_FOR(ioserialiser_cmwlight_test::SimpleTestDataMoreFields, a2, ab2, abc2, b2, c2, cd2, ce2, d2, e2, a, ab, abc, b, c, cd, ce, d, e)
+
+#pragma clang diagnostic pop
+TEST_CASE("IoClassSerialiserCmwLight missing field", "[IoClassSerialiser]") {
+    using namespace opencmw;
+    using namespace opencmw::utils; // for operator<< and fmt::format overloading
+    using namespace ioserialiser_cmwlight_test;
+    debug::resetStats();
+    {
+        debug::Timer timer("IoClassSerialiser basic syntax", 30);
+
+        IoBuffer     buffer;
+        std::cout << fmt::format("buffer size (before): {} bytes\n", buffer.size());
+
+        SimpleTestData data{
+            .a   = 30,
+            .ab  = 1.2f,
+            .abc = 1.23,
+            .b   = "abc",
+            .c   = { 5, 4, 3 },
+            .cd  = { 2.1, 4.2 },
+            .ce  = { "hallo", "welt" },
+            .d   = { { 6, 5, 4, 3, 2, 1 }, { 3, 2 } }
+        };
+        SimpleTestDataMoreFields data2;
+        std::cout << fmt::format("object (fmt): {}\n", data);
+        opencmw::serialise<opencmw::CmwLight>(buffer, data);
+        buffer.reset();
+        auto result = opencmw::deserialise<opencmw::CmwLight, ProtocolCheck::LENIENT>(buffer, data2);
+        std::cout << fmt::format("deserialised object (fmt): {}\n", data2);
+        std::cout << "deserialisation messages: " << result << std::endl;
+        REQUIRE(result.setFields["root"] == std::vector<bool>{ 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 0 });
+        REQUIRE(result.additionalFields.empty());
+        REQUIRE(result.exceptions.empty());
+
+        std::cout << "\nand now the other way round!\n\n";
+        buffer.clear();
+        opencmw::serialise<opencmw::CmwLight>(buffer, data2);
+        buffer.reset();
+        auto result_back = opencmw::deserialise<opencmw::CmwLight, ProtocolCheck::LENIENT>(buffer, data);
+        std::cout << fmt::format("deserialised object (fmt): {}\n", data);
+        std::cout << "deserialisation messages: " << result_back << std::endl;
+        REQUIRE(result_back.setFields["root"] == std::vector<bool>{ 1, 1, 1, 1, 1, 1, 1, 1, 0 });
+        REQUIRE(result_back.additionalFields.size() == 8);
+        REQUIRE(result_back.exceptions.size() == 8);
+    }
+    REQUIRE(opencmw::debug::dealloc == opencmw::debug::alloc); // a memory leak occurred
+    debug::resetStats();
+}

--- a/src/serialiser/test/IoSerialiserJson_tests.cpp
+++ b/src/serialiser/test/IoSerialiserJson_tests.cpp
@@ -120,18 +120,18 @@ TEST_CASE("JsonArraySerialisation", "[JsonSerialiser]") {
     {
         std::vector<int>  test{ 1, 3, 3, 7 };
         opencmw::IoBuffer buffer;
-        opencmw::IoSerialiser<opencmw::Json, std::vector<int>>::serialise(buffer, detail::newFieldHeader<opencmw::Json>(buffer, "test", 0, test), test);
+        opencmw::IoSerialiser<opencmw::Json, std::vector<int>>::serialise(buffer, detail::newFieldHeader<opencmw::Json>(buffer, "test", 0, test, 0), test);
         REQUIRE(buffer.asString() == "[1, 3, 3, 7]");
         {
             std::vector<int> result;
-            opencmw::IoSerialiser<opencmw::Json, std::vector<int>>::deserialise(buffer, detail::newFieldHeader<opencmw::Json>(buffer, "test", 0, result), result);
+            opencmw::IoSerialiser<opencmw::Json, std::vector<int>>::deserialise(buffer, detail::newFieldHeader<opencmw::Json>(buffer, "test", 0, result, 0), result);
             REQUIRE(test == result);
             REQUIRE(buffer.position() == 12);
         }
         buffer.set_position(0);
         {
             std::array<int, 4> resultArray;
-            opencmw::IoSerialiser<opencmw::Json, std::array<int, 4>>::deserialise(buffer, detail::newFieldHeader<opencmw::Json>(buffer, "test", 0, resultArray), resultArray);
+            opencmw::IoSerialiser<opencmw::Json, std::array<int, 4>>::deserialise(buffer, detail::newFieldHeader<opencmw::Json>(buffer, "test", 0, resultArray, 0), resultArray);
             REQUIRE(test == std::vector<int>(resultArray.begin(), resultArray.end()));
             REQUIRE(buffer.position() == 12);
         }
@@ -139,10 +139,10 @@ TEST_CASE("JsonArraySerialisation", "[JsonSerialiser]") {
     { // empty vector
         std::vector<int>  test{};
         opencmw::IoBuffer buffer;
-        opencmw::IoSerialiser<opencmw::Json, std::vector<int>>::serialise(buffer, detail::newFieldHeader<opencmw::Json>(buffer, "test", 0, test), test);
+        opencmw::IoSerialiser<opencmw::Json, std::vector<int>>::serialise(buffer, detail::newFieldHeader<opencmw::Json>(buffer, "test", 0, test, 0), test);
         REQUIRE(buffer.asString() == "[]");
         std::vector<int> result;
-        opencmw::IoSerialiser<opencmw::Json, std::vector<int>>::deserialise(buffer, detail::newFieldHeader<opencmw::Json>(buffer, "test", 0, result), result);
+        opencmw::IoSerialiser<opencmw::Json, std::vector<int>>::deserialise(buffer, detail::newFieldHeader<opencmw::Json>(buffer, "test", 0, result, 0), result);
         REQUIRE(test == result);
         REQUIRE(buffer.position() == 2);
     }


### PR DESCRIPTION
(De-)serialisation for the CMW middleware wire protocol.

TODO:
- [x] treatment of missing fields/domain object differences (different from other protocols because there is no easy way to skip fields, one has to keep deserialising, ignore the result and count the number of deserialised fields)