### PR TITLE
IoSerialiserJson: implement Map<String,V> serialisation and small fixes

### DIFF
--- a/concepts/serialiser/JsonExample.cpp
+++ b/concepts/serialiser/JsonExample.cpp
@@ -1,18 +1,19 @@
-#include <IoSerialiserJson.hpp>
-#include <Utils.hpp>
 #include <array>
+#include <IoSerialiserJson.hpp>
 #include <iostream>
 #include <memory>
+#include <Utils.hpp>
 
 struct DataY {
-    int8_t                 byteValue   = 1;
-    int16_t                shortValue  = 2;
-    int32_t                intValue    = 3;
-    int64_t                longValue   = 4;
-    float                  floatValue  = 5.0F;
-    double                 doubleValue = 6.0;
-    std::string            stringValue;
-    std::array<double, 10> doubleArray = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
+    int8_t                        byteValue   = 1;
+    int16_t                       shortValue  = 2;
+    int32_t                       intValue    = 3;
+    int64_t                       longValue   = 4;
+    float                         floatValue  = 5.0F;
+    double                        doubleValue = 6.0;
+    std::string                   stringValue;
+    std::array<double, 10>        doubleArray = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
+    std::map<std::string, double> doubleMap{ std::pair<std::string, double>{ "Hello", 4 }, std::pair<std::string, double>{ "Map", 1.3 } };
     // std::vector<float>             floatVector      = { 0.1F, 1.1F, 2.1F, 3.1F, 4.1F, 5.1F, 6.1F, 8.1F, 9.1F, 9.1F }; // causes SEGFAULT
     // opencmw::MultiArray<double, 2> doubleMatrix{ { 1, 3, 7, 4, 2, 3 }, { 2, 3 } };
     std::shared_ptr<DataY> nested;
@@ -21,7 +22,7 @@ struct DataY {
     bool operator==(const DataY &) const = default;
 };
 // following is the visitor-pattern-macro that allows the compile-time reflections via refl-cpp
-ENABLE_REFLECTION_FOR(DataY, byteValue, shortValue, intValue, longValue, floatValue, doubleValue, stringValue, doubleArray, /*floatVector,*/ nested)
+ENABLE_REFLECTION_FOR(DataY, byteValue, shortValue, intValue, longValue, floatValue, doubleValue, stringValue, doubleArray, doubleMap, /*floatVector,*/ nested)
 
 /**
  * Serialisation example with nested classes and deserialisation into different type.
@@ -37,7 +38,7 @@ int main() {
     std::cout << "serialised: " << buffer.asString() << std::endl;
     DataY bar;
     auto  result = opencmw::deserialise<opencmw::Json, opencmw::ProtocolCheck::LENIENT>(buffer, bar);
-    //opencmw::utils::diffView(std::cout, foo, bar); // todo: produces SEGFAULT
+    // opencmw::utils::diffView(std::cout, foo, bar); // todo: produces SEGFAULT
     fmt::print(std::cout, "deserialisation finished: {}\n", result);
     opencmw::IoBuffer buffer2;
     opencmw::serialise<opencmw::Json>(buffer2, foo);

--- a/src/majordomo/test/majordomoworker_tests.cpp
+++ b/src/majordomo/test/majordomoworker_tests.cpp
@@ -159,7 +159,7 @@ TEST_CASE("Simple MajordomoWorker example showing its usage", "[majordomo][major
         REQUIRE(reply->clientRequestId() == "1");
         REQUIRE(reply->error() == "");
         REQUIRE(reply->topic() == "/addresses?contentType=application%2Fjson&ctx=FAIR.SELECTOR.ALL");
-        REQUIRE(reply->body() == "\"AddressEntry\": {\n\"name\": \"Santa Claus\",\n\"street\": \"Elf Road\",\n\"streetNumber\": 123,\n\"postalCode\": \"88888\",\n\"city\": \"North Pole\",\n}");
+        REQUIRE(reply->body() == "\"AddressEntry\": {\n\"name\": \"Santa Claus\",\n\"street\": \"Elf Road\",\n\"streetNumber\": 123,\n\"postalCode\": \"88888\",\n\"city\": \"North Pole\"\n}");
     }
 }
 
@@ -199,7 +199,7 @@ TEST_CASE("MajordomoWorker test using raw messages", "[majordomo][majordomoworke
         REQUIRE(reply->clientRequestId() == "1");
         REQUIRE(reply->error() == "");
         REQUIRE(reply->topic() == "/addresses?contentType=application%2Fjson&ctx=FAIR.SELECTOR.ALL");
-        REQUIRE(reply->body() == "\"AddressEntry\": {\n\"name\": \"Santa Claus\",\n\"street\": \"Elf Road\",\n\"streetNumber\": 123,\n\"postalCode\": \"88888\",\n\"city\": \"North Pole\",\n}");
+        REQUIRE(reply->body() == "\"AddressEntry\": {\n\"name\": \"Santa Claus\",\n\"street\": \"Elf Road\",\n\"streetNumber\": 123,\n\"postalCode\": \"88888\",\n\"city\": \"North Pole\"\n}");
     }
 
     // GET with unknown role or empty role fails
@@ -319,6 +319,6 @@ TEST_CASE("MajordomoWorker test using raw messages", "[majordomo][majordomoworke
         REQUIRE(notify->sourceId() == "/newAddress?ctx=FAIR.SELECTOR.C=1");
         REQUIRE(notify->topic() == "/newAddress?contentType=application%2Fjson&ctx=FAIR.SELECTOR.C%3D1");
         REQUIRE(notify->error().empty());
-        REQUIRE(notify->body() == "\"AddressEntry\": {\n\"name\": \"Easter Bunny\",\n\"street\": \"Carrot Road\",\n\"streetNumber\": 123,\n\"postalCode\": \"88888\",\n\"city\": \"Easter Island\",\n}");
+        REQUIRE(notify->body() == "\"AddressEntry\": {\n\"name\": \"Easter Bunny\",\n\"street\": \"Carrot Road\",\n\"streetNumber\": 123,\n\"postalCode\": \"88888\",\n\"city\": \"Easter Island\"\n}");
     }
 }

--- a/src/serialiser/include/IoSerialiserJson.hpp
+++ b/src/serialiser/include/IoSerialiserJson.hpp
@@ -209,7 +209,13 @@ struct FieldHeaderWriter<Json> {
             return 0;
         }
         if constexpr (std::is_same_v<DataType, END_MARKER>) {
-            buffer.put('}');
+            if (buffer.template at<uint8_t>(buffer.size() - 2) == ',') {
+                // proceeded by value, remove trailing comma
+                buffer.resize(buffer.size() - 2);
+                buffer.put<WITHOUT>("\n}"sv);
+            } else {
+                buffer.put('}');
+            }
             return 0;
         }
         buffer.put<WITHOUT>("\""sv);


### PR DESCRIPTION
Implement a serialiser for maps with strings as keys.
Removes the trailing commas after the last field of an object.
Implements the deserialiser for the MultiArray type (was missing until now and related to the map deserialiser).