### PR TITLE
updated and made TimingCtx reflectable

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -1,6 +1,6 @@
 # setup header only library
 add_library(core INTERFACE)
-target_include_directories(core INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include> $<INSTALL_INTERFACE:${CMAKE_INSTALL_PREFIX}/include/>)
+target_include_directories(core INTERFACE $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/src/serialiser/include> $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include> $<INSTALL_INTERFACE:${CMAKE_INSTALL_PREFIX}/include/>)
 target_link_libraries(core INTERFACE CONAN_PKG::mp-units refl-cpp::refl-cpp utils pthread)
 set_target_properties(core PROPERTIES PUBLIC_HEADER "include/URI.hpp;include/MIME.hpp")
 

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -1,6 +1,6 @@
 # setup header only library
 add_library(core INTERFACE)
-target_include_directories(core INTERFACE $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/src/serialiser/include> $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include> $<INSTALL_INTERFACE:${CMAKE_INSTALL_PREFIX}/include/>)
+target_include_directories(core INTERFACE $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/src/serialiser/include> $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include> $<INSTALL_INTERFACE:${CMAKE_INSTALL_PREFIX}/include/>) #TODO: remove serialiser dependency once TimingCtx is moved
 target_link_libraries(core INTERFACE CONAN_PKG::mp-units refl-cpp::refl-cpp utils pthread)
 set_target_properties(core PROPERTIES PUBLIC_HEADER "include/URI.hpp;include/MIME.hpp")
 

--- a/src/core/include/TimingCtx.hpp
+++ b/src/core/include/TimingCtx.hpp
@@ -52,13 +52,7 @@ public:
 
     [[nodiscard]] auto operator<=>(const TimingCtx &other) const {
         parse();
-        // clang-format off
-        if (_cid != other._cid) { return _cid <=> other._cid; }
-        if (_sid != other._sid) { return _sid <=> other._sid; }
-        if (_pid != other._pid) { return _pid <=> other._pid; }
-        if (_gid != other._gid) { return _gid <=> other._gid; }
-        // clang-format on
-        return bpcts <=> other.bpcts;
+        return std::tie(_cid, _sid, _pid, _gid, bpcts) <=> std::tie(other._cid, other._sid, other._pid, other._gid, other.bpcts);
     }
     [[nodiscard]] bool operator==(const TimingCtx &other) const {
         parse();
@@ -173,14 +167,13 @@ public:
     }
 
 private:
-    [[nodiscard]] static constexpr std::optional<int> asOptional(int x) noexcept { return x == WILDCARD_VALUE ? std::nullopt : std::optional<int>{ x }; }
-    [[nodiscard]] static constexpr bool               isWildcard(int x) noexcept { return x == -1; }
-    [[nodiscard]] static constexpr bool               wildcardMatch(int lhs, int rhs) { return isWildcard(rhs) || lhs == rhs; }
-    [[nodiscard]] static constexpr bool               bpcTimeStampMatch(std::chrono::microseconds lhs, std::chrono::microseconds rhs) { return rhs.count() == 0 || lhs.count() == rhs.count(); }
-    static inline std::string                         toUpper(const std::string_view &mixedCase) noexcept {
+    [[nodiscard]] static constexpr bool isWildcard(int x) noexcept { return x == -1; }
+    [[nodiscard]] static constexpr bool wildcardMatch(int lhs, int rhs) { return isWildcard(rhs) || lhs == rhs; }
+    [[nodiscard]] static constexpr bool bpcTimeStampMatch(std::chrono::microseconds lhs, std::chrono::microseconds rhs) { return rhs.count() == 0 || lhs.count() == rhs.count(); }
+    static inline std::string           toUpper(const std::string_view &mixedCase) noexcept {
         std::string retval;
-        retval.reserve(mixedCase.size());
-        std::ranges::transform(mixedCase.cbegin(), mixedCase.cend(), std::back_inserter(retval), [](char c) noexcept { return (c >= 'a' && c <= 'z') ? c - ('a' - 'A') : c; });
+        retval.resize(mixedCase.size());
+        std::ranges::transform(mixedCase, retval.begin(), [](char c) noexcept { return (c >= 'a' && c <= 'z') ? c - ('a' - 'A') : c; });
         return retval;
     }
 };

--- a/src/majordomo/include/majordomo/QuerySerialiser.hpp
+++ b/src/majordomo/include/majordomo/QuerySerialiser.hpp
@@ -138,7 +138,6 @@ C deserialise(const QueryMap &m) {
             // TODO handle vectors? QueryMap would have to be a multimap
 
             static_assert(!is_smart_pointer<std::remove_reference_t<MemberType>>, "Pointer members not handled");
-            static_assert(!isReflectableClass<MemberType>(), "Nested structures not supported in query");
 
             const std::string fieldName{ member.name.c_str(), member.name.size };
             try {
@@ -168,7 +167,6 @@ QueryMap serialise(const C &context) {
             // TODO handle vectors? QueryMap would have to be a multimap
 
             static_assert(!is_smart_pointer<std::remove_reference_t<MemberType>>, "Pointer members not handled");
-            static_assert(!isReflectableClass<MemberType>(), "Nested structures not supported in query");
 
             const std::string fieldName{ member.name.c_str(), member.name.size };
             QuerySerialiser<MemberType>::serialise(result, fieldName, member(context));
@@ -184,7 +182,6 @@ void registerTypes(const C &context, T &registerAt) {
         if constexpr (is_field(member) && !is_static(member)) {
             using MemberType = std::remove_reference_t<decltype(getAnnotatedMember(unwrapPointer(member(context))))>;
             static_assert(!is_smart_pointer<std::remove_reference_t<MemberType>>, "Pointer members not handled");
-            static_assert(!isReflectableClass<MemberType>(), "Nested structures not supported");
 
             const std::string fieldName{ member.name.c_str(), member.name.size };
 

--- a/src/majordomo/test/majordomoworker_tests.cpp
+++ b/src/majordomo/test/majordomoworker_tests.cpp
@@ -292,7 +292,7 @@ TEST_CASE("MajordomoWorker test using raw messages", "[majordomo][majordomoworke
             .postalCode   = "88888",
             .city         = "Sahara"
         };
-        REQUIRE(worker.notify("/newAddress", TestContext{ .ctx = opencmw::TimingCtx({}, 1, {}, {}), .contentType = opencmw::MIME::JSON }, entry));
+        REQUIRE(worker.notify("/newAddress", TestContext{ .ctx = opencmw::TimingCtx(-1, 1, -1, -1), .contentType = opencmw::MIME::JSON }, entry));
     }
 
     {
@@ -305,7 +305,7 @@ TEST_CASE("MajordomoWorker test using raw messages", "[majordomo][majordomoworke
             .postalCode   = "88888",
             .city         = "Easter Island"
         };
-        REQUIRE(worker.notify("/newAddress", TestContext{ .ctx = opencmw::TimingCtx(1, {}, {}, {}), .contentType = opencmw::MIME::JSON }, entry));
+        REQUIRE(worker.notify("/newAddress", TestContext{ .ctx = opencmw::TimingCtx(1), .contentType = opencmw::MIME::JSON }, entry));
     }
 
     {

--- a/src/majordomo/test/restserver_testapp.cpp
+++ b/src/majordomo/test/restserver_testapp.cpp
@@ -52,16 +52,12 @@ ENABLE_REFLECTION_FOR(AddressEntry, name, street, streetNumber, postalCode, city
  * The handler implementing the MajordomoHandler concept, here holding a single hardcoded address entry.
  */
 struct TestAddressHandler {
-    AddressEntry _entry;
-
-    TestAddressHandler()
-        : _entry{ "Santa Claus", "Elf Road", 123, "88888", "North Pole", true } {
-    }
+    AddressEntry _entry = { "Santa Claus", "Elf Road", 123, "88888", "North Pole", true };
 
     /**
      * The handler function that the handler is required to implement.
      */
-    void operator()(opencmw::majordomo::RequestContext &rawCtx, const TestContext & /*requestContext*/, const AddressRequest &request, TestContext & /*replyContext*/, AddressEntry &output) {
+    void operator()(const opencmw::majordomo::RequestContext &rawCtx, const TestContext & /*requestContext*/, const AddressRequest &request, TestContext & /*replyContext*/, AddressEntry &output) {
         if (rawCtx.request.command() == Command::Get) {
             output = _entry;
         } else if (rawCtx.request.command() == Command::Set) {
@@ -189,7 +185,7 @@ int main(int argc, char **argv) {
             .city         = "Easter Island",
             .isCurrent    = false
         };
-        workerA.notify("/addresses", TestContext{ .ctx = opencmw::TimingCtx(1, {}, {}, {}), .contentType = opencmw::MIME::JSON }, entry);
+        workerA.notify("/addresses", TestContext{ .ctx = opencmw::TimingCtx(1), .contentType = opencmw::MIME::JSON }, entry);
 
         std::this_thread::sleep_for(5s);
     }


### PR DESCRIPTION
* TimingCtx is now reflectable (string selector + bpcts are public now)
* fixed clang-tidy, sonartype and PMD issues
* added spaceship and fast short-circuiting == operators
* refactored state/field variables to the top
* forced upper-case for selector (also simplifies parsing)
* fixed syntax, selector may be either "" == "ALL" == "FAIR.SELECTOR.ALL", or "FAIR.SELECTOR.[C...]" only
* included bpcts into comparisons (if set)