### PR TITLE
compile-time type-constrained collection

### DIFF
--- a/concepts/core/CMakeLists.txt
+++ b/concepts/core/CMakeLists.txt
@@ -1,2 +1,5 @@
+add_executable(collection_example collection_example.cpp)
+target_link_libraries(collection_example PRIVATE core project_options project_warnings)
+
 add_executable(URI_example URI_example.cpp)
 target_link_libraries(URI_example PRIVATE core project_options project_warnings)

--- a/concepts/core/collection_example.cpp
+++ b/concepts/core/collection_example.cpp
@@ -1,0 +1,48 @@
+#include <cassert>
+#include <chrono>
+#include <fmt/format.h>
+
+#include <collection.hpp>
+
+template<typename T>
+concept Arithmetic = std::is_arithmetic_v<T>;
+
+template<Arithmetic... Ts>
+void function(opencmw::collection<Ts...> &c) {
+    std::size_t foo = 1;
+    c.visit([](auto &arg) noexcept { arg *= 1; },
+            [&foo](size_t &arg) noexcept { arg *= foo; },
+            [](float &arg) noexcept { arg *= 1; },
+            [](char &arg) noexcept { arg *= 1; });
+}
+/**
+ * Example to demonstrate the compile-time type-constrained collection
+ */
+int main() {
+    using opencmw::collection;
+    // some simple benchmarks for writing/reading (visiting)
+    const auto nRepetitions = 1'000'000U;
+    auto       time_start   = std::chrono::system_clock::now();
+
+    // explicit declaration
+    collection<size_t, float, char> c;
+    // alternate list-style construction:
+    [[maybe_unused]] auto c1 = collection{ 1LU, 1.0f, 'a' };
+    c1.push_back('b');
+    c1.push_back('c');
+    [[maybe_unused]] collection c2 = { 1LU, 1.0f, 'a', 'b', 'c' };
+    assert(c1 == c2);
+
+    for (size_t i = 0; i < nRepetitions; ++i) {
+        c.push_back(i);
+        c.push_back(static_cast<float>(i));
+        c.push_back(static_cast<char>(i % 256));
+        // c.push_back(static_cast<short>(i % 256)); // correctly fails - 'short' not part of class definition
+    }
+    for (size_t i = 0; i < nRepetitions; ++i) {
+        function(c);
+    }
+
+    std::chrono::duration<double, std::milli> time_elapsed = std::chrono::system_clock::now() - time_start;
+    fmt::print("push_back and visit (fixed types): {} milliseconds or {} ops/s\n", time_elapsed.count(), (1000 * nRepetitions / time_elapsed.count()));
+}

--- a/src/core/include/collection.hpp
+++ b/src/core/include/collection.hpp
@@ -36,60 +36,69 @@ namespace opencmw {
  * @authors Matthias Kretz (@mattkretz), Ralph J. Steinhagen (@RalphSteinhagen)
  */
 template<typename... Ts>
-class collection {
-    tuple_unique<std::tuple<std::vector<Ts>...>> _items;
+class collection;
+
+template<typename... Ts>
+requires is_uniq<Ts...>::value class collection<Ts...> {
+    std::tuple<std::vector<Ts>...> _items;
 
 public:
     // clang-format off
     constexpr collection() noexcept = default;
-    constexpr collection(Ts... element) noexcept { (..., push_back(element)); }
-    [[nodiscard]] constexpr std::size_t size() const noexcept { std::size_t size = 0; std::apply([&size]<typename... T>(T & ...v) { (..., (size += v.size())); }, _items); return size; }
-    [[nodiscard]] constexpr bool        empty() const noexcept { return size() == 0; }
-    void                                clear() noexcept { std::apply([]<typename... T>(T & ...v) { (..., v.clear()); }, _items);}
+    template <typename... Us>
+    requires std::conjunction_v<is_in_list<std::decay_t<Us>, Ts...>...>
+    explicit constexpr collection(Us &&...elements) noexcept { (..., push_back(std::forward<Us>(elements))); }
+    [[nodiscard]] constexpr std::size_t size() const noexcept { return (... + std::get<std::vector<Ts> >(_items).size()); }
+    [[nodiscard]] constexpr bool        empty() const noexcept { return (... && std::get<std::vector<Ts> >(_items).empty()); }
+    void                                clear() noexcept { (..., std::get<std::vector<Ts> >(_items).clear()); }
     void                                reserve(std::size_t count) { std::apply([&count]<typename... T>(T & ...v) { (..., v.reserve(count)); }, _items);}
     [[nodiscard]] constexpr std::size_t capacity() const noexcept { std::size_t size = 0; std::apply([&size]<typename... T>(T & ...v) { (..., (size = std::max(size, v.capacity()))); }, _items); return size; }
     // clang-format on
 
     template<typename T>
-    requires std::disjunction_v<std::is_same<std::remove_cvref_t<T>, Ts>...>
+    requires std::disjunction_v<std::is_same<std::decay_t<T>, Ts>...>
     void push_back(T &&e) {
-        std::get<std::vector<std::remove_cvref_t<T>>>(_items).push_back(std::forward<T>(e));
+        std::get<std::vector<std::decay_t<T>>>(_items).push_back(std::forward<T>(e));
     }
 
     template<typename T>
-    requires std::disjunction_v<std::is_same<std::remove_cvref_t<T>, Ts>...>
+    requires std::disjunction_v<std::is_same<std::decay_t<T>, Ts>...>
     void remove(T &&e) noexcept {
-        auto &vec = std::get<std::vector<std::remove_cvref_t<T>>>(_items);
-        if (const auto pos = std::ranges::find(vec.begin(), vec.end(), e); pos != vec.end()) {
-            vec.erase(pos, pos + 1);
-        }
+        auto &vec = std::get<std::vector<std::decay_t<T>>>(_items);
+        vec.erase(std::ranges::remove(vec, std::forward<T>(e)).begin(), vec.end());
     }
 
     template<typename... F>
     requires(sizeof...(F) > 0) void visit(F &&...visitors) {
         overloaded visitor{ std::forward<F>(visitors)... };
-        std::apply([&visitor](auto &&...vs) {
-            (..., [&visitor](auto &v) {
-                std::ranges::for_each(v, [&visitor](auto &&e) { visitor(std::forward<decltype(e)>(e)); });
-            }(std::forward<decltype(vs)>(vs)));
-        },
-                _items);
+        (..., std::ranges::for_each(std::get<std::vector<Ts>>(_items), visitor));
     }
 
-    template<typename... Ts1, typename... Ts2>
-    friend constexpr auto operator<=>(const collection<Ts1...> &lhs, const collection<Ts2...> &rhs) noexcept;
-    template<typename... Ts1, typename... Ts2>
-    friend constexpr bool operator==(const collection<Ts1...> &lhs, const collection<Ts2...> &rhs) noexcept;
+    constexpr auto operator<=>(const collection &) const = default;
 
 private:
     template<class... Us>
     struct overloaded : Us... { using Us::operator()...; };
 };
 
-template<typename... Ts1, typename... Ts2>
-constexpr auto operator<=>(const collection<Ts1...> &lhs, const collection<Ts2...> &rhs) noexcept { return lhs._items <=> rhs._items; }
-template<typename... Ts1, typename... Ts2>
-constexpr bool operator==(const collection<Ts1...> &lhs, const collection<Ts2...> &rhs) noexcept { return lhs._items == rhs._items; }
+template<typename... Ts>
+requires(!is_uniq<Ts...>::value) class collection<Ts...> : public filter_duplicates_t<collection, Ts...> {
+    using Base = filter_duplicates_t<collection, Ts...>;
+
+public:
+    constexpr collection() noexcept              = default;
+    constexpr collection(const collection &)     = default;
+    constexpr collection(collection &&) noexcept = default;
+
+    template<typename... Us>
+    requires std::conjunction_v<is_in_list<std::decay_t<Us>, Ts...>...>
+    constexpr collection(Us &&...args)
+        : Base(std::forward<Us>(args)...) {}
+};
+
+// deduction guide is necessary
+template<typename... Ts>
+collection(Ts...) -> collection<Ts...>;
 
 } // namespace opencmw
 

--- a/src/core/include/collection.hpp
+++ b/src/core/include/collection.hpp
@@ -33,6 +33,10 @@ namespace opencmw {
  * auto       c1 = collection{1LU, 1.0f, 'c'};
  * collection c2 = {1LU, 1.0f, 'c'};
  *
+ * N.B. While the visitation is (presently) ordered as the type template argument list and
+ * within a type by insertion order, the ordering of items on visitation is unspecified and
+ * should be considered as 'unsorted'.
+ *
  * @authors Matthias Kretz (@mattkretz), Ralph J. Steinhagen (@RalphSteinhagen)
  */
 template<typename... Ts>

--- a/src/core/include/collection.hpp
+++ b/src/core/include/collection.hpp
@@ -1,0 +1,93 @@
+#ifndef OPENCMW_CPP_COLLECTION_H
+#define OPENCMW_CPP_COLLECTION_H
+
+#include <algorithm>
+#include <tuple>
+#include <vector>
+
+#include <opencmw.hpp>
+
+namespace opencmw {
+
+/**
+ * <h2>compile-time type-constrained collection</h2>
+ *
+ * <p>
+ * It is intended to be used with concept constraints to exchange collections of heterogeneous types <br>
+ * as parameters between user-code and methods, e.g. (N.B. 'DataSet' being a concept type-constraint):
+ * @code
+ * template &#60;DataSet... Ts&#62;
+ * void func(const opencmw::collection&#60;Ts...&#62; &) { ... }
+ *
+ * <b>usage examples:</b>
+ * using opencmw::collection;
+ * collection&#60;size_t, float, char&#62; c {1LU, 1.0f, 'a'};
+ *   c.push_back('c');
+ *
+ *   c.visit([](size_t &arg) noexcept { ... }, &#47;&#47; need one type-specific visitor for each type:
+ *     [](float &arg) noexcept { ... },
+ *     [](char &arg) noexcept { ... },
+ *     []<typename T>(T &arg) noexcept { ... }); &#47;&#47; and/or: generic type fall-back visitor lambda.
+ *
+ * <b>alternate list-style construction:</b>
+ * auto       c1 = collection{1LU, 1.0f, 'c'};
+ * collection c2 = {1LU, 1.0f, 'c'};
+ *
+ * @authors Matthias Kretz (@mattkretz), Ralph J. Steinhagen (@RalphSteinhagen)
+ */
+template<typename... Ts>
+class collection {
+    tuple_unique<std::tuple<std::vector<Ts>...>> _items;
+
+public:
+    // clang-format off
+    constexpr collection() noexcept = default;
+    constexpr collection(Ts... element) noexcept { (..., push_back(element)); }
+    [[nodiscard]] constexpr std::size_t size() const noexcept { std::size_t size = 0; std::apply([&size]<typename... T>(T & ...v) { (..., (size += v.size())); }, _items); return size; }
+    [[nodiscard]] constexpr bool        empty() const noexcept { return size() == 0; }
+    void                                clear() noexcept { std::apply([]<typename... T>(T & ...v) { (..., v.clear()); }, _items);}
+    void                                reserve(std::size_t count) { std::apply([&count]<typename... T>(T & ...v) { (..., v.reserve(count)); }, _items);}
+    [[nodiscard]] constexpr std::size_t capacity() const noexcept { std::size_t size = 0; std::apply([&size]<typename... T>(T & ...v) { (..., (size = std::max(size, v.capacity()))); }, _items); return size; }
+    // clang-format on
+
+    template<typename T>
+    requires std::disjunction_v<std::is_same<std::decay_t<T>, Ts>...>
+    void push_back(T &&e) noexcept {
+        std::get<std::vector<std::remove_cvref_t<T>>>(_items).push_back(std::forward<T>(e));
+    }
+
+    template<typename T>
+    requires std::disjunction_v<std::is_same<std::decay_t<T>, Ts>...>
+    void remove(T &&e) noexcept {
+        std::get<std::vector<std::remove_cvref_t<T>>>(_items).remove(std::forward<T>(e));
+    }
+
+    template<typename... F>
+    requires(sizeof...(F) > 0) void visit(F &&...visitors) {
+        overloaded visitor{ std::forward<F>(visitors)... };
+        std::apply([&visitor](auto &&...vs) {
+            (..., [&visitor](auto &v) {
+                std::ranges::for_each(v, [&visitor](auto &&e) { visitor(std::forward<decltype(e)>(e)); });
+            }(std::forward<decltype(vs)>(vs)));
+        },
+                _items);
+    }
+
+    template<typename... Ts1, typename... Ts2>
+    friend constexpr auto operator<=>(const collection<Ts1...> &lhs, const collection<Ts2...> &rhs) noexcept;
+    template<typename... Ts1, typename... Ts2>
+    friend constexpr bool operator==(const collection<Ts1...> &lhs, const collection<Ts2...> &rhs) noexcept;
+
+private:
+    template<class... Us>
+    struct overloaded : Us... { using Us::operator()...; };
+};
+
+template<typename... Ts1, typename... Ts2>
+constexpr auto operator<=>(const collection<Ts1...> &lhs, const collection<Ts2...> &rhs) noexcept { return lhs._items <=> rhs._items; }
+template<typename... Ts1, typename... Ts2>
+constexpr bool operator==(const collection<Ts1...> &lhs, const collection<Ts2...> &rhs) noexcept { return lhs._items == rhs._items; }
+
+} // namespace opencmw
+
+#endif // OPENCMW_CPP_COLLECTION_H

--- a/src/core/include/collection.hpp
+++ b/src/core/include/collection.hpp
@@ -51,15 +51,18 @@ public:
     // clang-format on
 
     template<typename T>
-    requires std::disjunction_v<std::is_same<std::decay_t<T>, Ts>...>
-    void push_back(T &&e) noexcept {
+    requires std::disjunction_v<std::is_same<std::remove_cvref_t<T>, Ts>...>
+    void push_back(T &&e) {
         std::get<std::vector<std::remove_cvref_t<T>>>(_items).push_back(std::forward<T>(e));
     }
 
     template<typename T>
-    requires std::disjunction_v<std::is_same<std::decay_t<T>, Ts>...>
+    requires std::disjunction_v<std::is_same<std::remove_cvref_t<T>, Ts>...>
     void remove(T &&e) noexcept {
-        std::get<std::vector<std::remove_cvref_t<T>>>(_items).remove(std::forward<T>(e));
+        auto &vec = std::get<std::vector<std::remove_cvref_t<T>>>(_items);
+        if (const auto pos = std::ranges::find(vec.begin(), vec.end(), e); pos != vec.end()) {
+            vec.erase(pos, pos + 1);
+        }
     }
 
     template<typename... F>

--- a/src/core/include/opencmw.hpp
+++ b/src/core/include/opencmw.hpp
@@ -195,6 +195,48 @@ requires(is_tuple<T>) using tuple_unique = typename detail::filter_tuple<std::tu
 template<template<typename...> typename Type, typename... Items>
 using find_type = decltype(std::tuple_cat(std::declval<std::conditional_t<is_instance_of_v<Items, Type>, std::tuple<Items>, std::tuple<>>>()...));
 
+template<typename T, typename... List>
+struct is_in_list : std::disjunction<std::is_same<T, List>...> {};
+
+template<typename... Ts>
+struct is_uniq : std::false_type {};
+
+template<>
+struct is_uniq<> : std::true_type {};
+
+template<typename T0, typename... Ts>
+requires(!is_in_list<T0, Ts...>::value) struct is_uniq<T0, Ts...> : is_uniq<Ts...> {};
+
+template<typename... Ts>
+struct type_list {};
+
+namespace detail {
+
+template<template<typename...> class C, typename Uniq, typename Input>
+struct filter_dups_impl {};
+
+template<template<typename...> class C, typename... Uniqs>
+struct filter_dups_impl<C, type_list<Uniqs...>, type_list<>> {
+    using type = C<Uniqs...>;
+};
+
+template<template<typename...> class C, typename... Uniqs, typename Input0, typename... Inputs>
+requires(... && !std::same_as<Input0, Uniqs>) struct filter_dups_impl<C, type_list<Uniqs...>, type_list<Input0, Inputs...>>
+    : filter_dups_impl<C, type_list<Uniqs..., Input0>, type_list<Inputs...>> {
+};
+
+template<template<typename...> class C, typename... Uniqs, typename Input0, typename... Inputs>
+requires(... || std::same_as<Input0, Uniqs>) struct filter_dups_impl<C, type_list<Uniqs...>, type_list<Input0, Inputs...>>
+    : filter_dups_impl<C, type_list<Uniqs...>, type_list<Inputs...>> {};
+
+template<template<typename...> class C, typename... Ts>
+struct filter_duplicates : filter_dups_impl<C, type_list<>, type_list<Ts...>> {
+};
+} // namespace detail
+
+template<template<typename...> class C, typename... Ts>
+using filter_duplicates_t = typename detail::filter_duplicates<C, Ts...>::type;
+
 // clang-format off
 /*
  * unit-/description-type annotation

--- a/src/core/include/opencmw.hpp
+++ b/src/core/include/opencmw.hpp
@@ -165,13 +165,13 @@ auto to_instance(From<Items...> from) -> To<Items...>;
 namespace detail {
 
 template<typename Out, typename... Ts>
-struct filter_tuple1 : std::type_identity<Out> {};
+struct filter_tuple : std::type_identity<Out> {};
 
 template<typename... Out, typename InCar, typename... InCdr> // template for std::tuple arguments
-struct filter_tuple1<std::tuple<Out...>, std::tuple<InCar, InCdr...>>
+struct filter_tuple<std::tuple<Out...>, std::tuple<InCar, InCdr...>>
     : std::conditional_t<(std::is_same_v<InCar, Out> || ...),
-              filter_tuple1<std::tuple<Out...>, std::tuple<InCdr...>>,
-              filter_tuple1<std::tuple<Out..., InCar>, std::tuple<InCdr...>>> {};
+              filter_tuple<std::tuple<Out...>, std::tuple<InCdr...>>,
+              filter_tuple<std::tuple<Out..., InCar>, std::tuple<InCdr...>>> {};
 
 template<typename Out, typename... Ts>
 struct filter_tuple2 : std::type_identity<Out> {};
@@ -190,7 +190,7 @@ template<typename... T>
 constexpr bool is_tuple<std::tuple<T...>> = true;
 
 template<class T>
-requires(is_tuple<T>) using tuple_unique = typename detail::filter_tuple1<std::tuple<>, T>::type;
+requires(is_tuple<T>) using tuple_unique = typename detail::filter_tuple<std::tuple<>, T>::type;
 
 template<template<typename...> typename Type, typename... Items>
 using find_type = decltype(std::tuple_cat(std::declval<std::conditional_t<is_instance_of_v<Items, Type>, std::tuple<Items>, std::tuple<>>>()...));

--- a/src/core/test/CMakeLists.txt
+++ b/src/core/test/CMakeLists.txt
@@ -1,6 +1,6 @@
 include(CTest)
 include(Catch)
-add_executable(core_tests catch_main.cpp 00_opencmw_basic_tests.cpp URI_tests.cpp MIME_tests.cpp TimingCtx_tests.cpp ThreadAffinity_tests.cpp)
+add_executable(core_tests catch_main.cpp 00_opencmw_basic_tests.cpp collection_tests.cpp URI_tests.cpp MIME_tests.cpp TimingCtx_tests.cpp ThreadAffinity_tests.cpp)
 target_link_libraries(core_tests PUBLIC project_warnings project_options CONAN_PKG::catch2 core pthread)
 # automatically discover tests that are defined in catch based test files you can modify the unittests. Set TEST_PREFIX to whatever you want, or use different for different binaries
 # catch_discover_tests(core_tests TEST_PREFIX  "unittests." REPORTER xml OUTPUT_DIR . OUTPUT_PREFIX "unittests." OUTPUT_SUFFIX .xml)

--- a/src/core/test/catch_main.cpp
+++ b/src/core/test/catch_main.cpp
@@ -1,3 +1,4 @@
 #define CATCH_CONFIG_MAIN // This tells the catch header to generate a main
+#define CATCH_CONFIG_ENABLE_BENCHMARKING 1
 
 #include <catch2/catch.hpp>

--- a/src/core/test/collection_tests.cpp
+++ b/src/core/test/collection_tests.cpp
@@ -1,0 +1,83 @@
+#define CATCH_CONFIG_ENABLE_BENCHMARKING 1
+#include <catch2/catch.hpp>
+
+#include <atomic>
+#include <iostream>
+
+#include "collection.hpp"
+
+TEST_CASE("basic tests", "[collection]") {
+    using opencmw::collection;
+
+    collection<size_t, float, char> testCollection1;
+    REQUIRE_NOTHROW(testCollection1.push_back(1LU));
+    REQUIRE_NOTHROW(testCollection1.push_back(1.0f));
+    // REQUIRE_NOTHROW(testCollection1.push_back(1.0)); // should not compile (wrong type)
+    REQUIRE_NOTHROW(testCollection1.push_back('c'));
+
+    std::atomic<int> counter1{ 0 };
+    std::atomic<int> counter2{ 0 };
+    std::atomic<int> counter3{ 0 };
+    std::atomic<int> counter4{ 0 };
+    testCollection1.visit(
+            [&counter1](const size_t &arg) noexcept { counter1++; REQUIRE(arg == 1LU); },
+            [&counter2](const float &arg) noexcept { counter2++; REQUIRE(arg == 1.0f); },
+            [&counter3](const char &arg) noexcept { counter3++; REQUIRE(arg == 'c'); },
+            [&counter4]<typename T>(const T &arg) noexcept { counter4++; arg *= 1; });
+    REQUIRE(counter1 == 1);
+    REQUIRE(counter2 == 1);
+    REQUIRE(counter3 == 1);
+    REQUIRE(counter4 == 0); // N.B. should not be called
+    testCollection1.visit([&counter4]<typename T>(T &arg) noexcept { counter4++; arg *= 1; });
+    REQUIRE(counter4 == 3); // default fall-back
+
+    counter4.store(0);
+    collection testCollection2(1, 1.0f, "Hello", "World!", std::vector<int>(2));
+    testCollection2.visit([&counter4]<typename T>(T &) noexcept { counter4++; });
+    REQUIRE(counter4 == 5); // default fall-back
+
+    collection testCollection3(testCollection2);
+    REQUIRE(testCollection3 == testCollection2);
+    testCollection2.push_back(1.0f);
+    REQUIRE(testCollection3 != testCollection2);
+
+    collection testCollection4 = testCollection2;
+    REQUIRE(testCollection4 == testCollection2);
+    testCollection2.push_back(1.0f);
+    REQUIRE(testCollection4 != testCollection2);
+
+    auto testCollection5 = collection{ 1LU, 1.0f, 'c' };
+    REQUIRE(testCollection5 == testCollection1);
+    testCollection1.push_back('b');
+    REQUIRE(testCollection5 != testCollection1);
+
+    auto testCollection6 = collection{ 1LU, 1.0f, 'c', 'b' };
+    REQUIRE(testCollection6 == testCollection1);
+    testCollection1.push_back('d');
+    REQUIRE(testCollection6 != testCollection1);
+
+    collection testCollection7 = { 1LU, 1.0f, 'c', 'b' };
+    REQUIRE(testCollection7.size() == 4);
+    REQUIRE(!testCollection7.empty());
+    testCollection7.clear();
+    REQUIRE(testCollection7.size() == 0);
+    REQUIRE(testCollection7.empty());
+
+    REQUIRE_NOTHROW(testCollection7.reserve(100));
+    REQUIRE(testCollection7.capacity() == 100);
+}
+
+TEST_CASE("mini collection benchmark", "[!benchmark]") {
+    auto miniTest = []() {
+        auto                time_start = std::chrono::system_clock::now();
+        opencmw::collection c{ 2UL, 1.0f, 'a' };
+        c.visit([](size_t &arg) noexcept { arg *= 1; },
+                [](float &arg) noexcept { arg *= 1; },
+                [](char &arg) noexcept { arg *= 1; },
+                []<typename T>(T &arg) noexcept { arg *= 1; });
+        return std::chrono::system_clock::now() - time_start;
+    };
+    BENCHMARK("collection") {
+        return miniTest();
+    };
+}

--- a/src/core/test/collection_tests.cpp
+++ b/src/core/test/collection_tests.cpp
@@ -71,6 +71,17 @@ TEST_CASE("basic tests", "[collection]") {
 
     REQUIRE_NOTHROW(testCollection7.reserve(100));
     REQUIRE(testCollection7.capacity() == 100);
+
+    counter4.store(0);
+    collection testCollection8(1, 1U, static_cast<short>(42));
+    // test concept constraint
+    auto testFunction = [&counter4]<std::integral... Ts>(collection<Ts...> & integralCollection) {
+        integralCollection.visit([&counter4]<std::integral T>(const T &) noexcept {
+            REQUIRE(std::is_integral_v<T>);
+            counter4++; });
+    };
+    testFunction(testCollection8);
+    REQUIRE(counter4 == 3);
 }
 
 TEST_CASE("mini collection benchmark", "[!benchmark]") {

--- a/src/core/test/collection_tests.cpp
+++ b/src/core/test/collection_tests.cpp
@@ -50,7 +50,13 @@ TEST_CASE("basic tests", "[collection]") {
     REQUIRE(testCollection5 == testCollection1);
     testCollection1.push_back('b');
     REQUIRE(testCollection5 != testCollection1);
+    REQUIRE(testCollection5.size() != testCollection1.size());
+    REQUIRE_NOTHROW(testCollection1.remove('b'));
+    REQUIRE_NOTHROW(testCollection1.remove('x'));
+    REQUIRE(testCollection5.size() == testCollection1.size());
+    REQUIRE(testCollection5 == testCollection1);
 
+    testCollection1.push_back('b');
     auto testCollection6 = collection{ 1LU, 1.0f, 'c', 'b' };
     REQUIRE(testCollection6 == testCollection1);
     testCollection1.push_back('d');


### PR DESCRIPTION
It is intended to be used with concept constraints to exchange collections of heterogeneous types <br>
as parameters between user-code and methods, e.g. (N.B. 'DataSet' being a concept type-constraint):

```cpp
template <DataSet... Ts>
void func(const opencmw::collection<Ts..> &dataSets) { ... }
```

<b>usage examples:</b>
```cpp
using opencmw::collection;
collection<size_t, float, char> c {1LU, 1.0f, 'a'};
c.push_back('c');

c.visit([](size_t &arg) noexcept { /*...*/ }, // need one type-specific visitor for each type:
    [](float &arg) noexcept { /*...*/ },
    [](char &arg) noexcept { /*...*/ },
    []<typename T>(T &arg) noexcept { /*...*/ }); // and/or: generic type fall-back visitor lambda.
```

<b>alternate list-style construction:</b>
```cpp
auto       c1 = collection{1LU, 1.0f, 'c'};
collection c2 = {1LU, 1.0f, 'c'};
```

authors: Matthias Kretz @mattkretz and Ralph J. Steinhagen @RalphSteinhagen