### PR TITLE
Cmake version checks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,10 @@ elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     message(FATAL_ERROR "Clang>=13.0.0 required, but clang ${CMAKE_CXX_COMPILER_VERSION} detected.")
   endif()
 else()
-  message(WARN "No version check for your compiler (${CMAKE_CXX_COMPILER_ID}) implemented, in case of build problems consider updating your compiler or check if you can switch to gcc or clang")
+  message(
+    WARN
+    "No version check for your compiler (${CMAKE_CXX_COMPILER_ID}) implemented, in case of build problems consider updating your compiler or check if you can switch to gcc or clang"
+  )
 endif()
 
 # Link this 'library' to set the c++ standard / compile-time options requested
@@ -55,7 +58,7 @@ enable_doxygen()
 include(cmake/StaticAnalyzers.cmake)
 
 option(ENABLE_TESTING "Enable Test Builds" ON)
-if (CMAKE_BUILD_TYPE STREQUAL "Debug" OR GENERATOR_IS_MULTI_CONFIG)
+if(CMAKE_BUILD_TYPE STREQUAL "Debug" OR GENERATOR_IS_MULTI_CONFIG)
   option(ENABLE_COVERAGE "Enable Coverage" ON)
 else()
   option(ENABLE_COVERAGE "Enable Coverage" OFF)
@@ -84,25 +87,46 @@ include(cmake/ReflCpp.cmake) # todo: switch to obtaining reflcpp from conan
 if(ENABLE_TESTING)
   enable_testing()
   message("Building Tests.")
-  if (ENABLE_COVERAGE)
+  if(ENABLE_COVERAGE)
     if(UNIX AND NOT APPLE) # Linux
       message("Coverage reporting enabled")
-      include(cmake/CodeCoverage.cmake) # https://github.com/bilke/cmake-modules/blob/master/CodeCoverage.cmake (License: BSL-1.0)
-      target_compile_options(project_options INTERFACE --coverage -O0 -g -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=0) # fortify_source is not possible without optimization
+      include(cmake/CodeCoverage.cmake) # https://github.com/bilke/cmake-modules/blob/master/CodeCoverage.cmake
+                                        # (License: BSL-1.0)
+      target_compile_options(
+        project_options
+        INTERFACE --coverage
+                  -O0
+                  -g
+                  -U_FORTIFY_SOURCE
+                  -D_FORTIFY_SOURCE=0) # fortify_source is not possible without optimization
       target_link_libraries(project_options INTERFACE --coverage)
       append_coverage_compiler_flags()
       setup_target_for_coverage_gcovr_xml(
-              NAME coverage
-              EXECUTABLE ctest
-              DEPENDENCIES core_tests majordomo_tests serialiser_tests
-              EXCLUDE "$CMAKE_BUILD_DIR/*" "concepts/.*" ".*/test/.*"
-      )
+        NAME
+        coverage
+        EXECUTABLE
+        ctest
+        DEPENDENCIES
+        core_tests
+        majordomo_tests
+        serialiser_tests
+        EXCLUDE
+        "$CMAKE_BUILD_DIR/*"
+        "concepts/.*"
+        ".*/test/.*")
       setup_target_for_coverage_gcovr_html(
-              NAME coverage_html
-              EXECUTABLE ctest
-              DEPENDENCIES core_tests majordomo_tests serialiser_tests
-              EXCLUDE "$CMAKE_BUILD_DIR/*" "concepts/.*" ".*/test/.*"
-      )
+        NAME
+        coverage_html
+        EXECUTABLE
+        ctest
+        DEPENDENCIES
+        core_tests
+        majordomo_tests
+        serialiser_tests
+        EXCLUDE
+        "$CMAKE_BUILD_DIR/*"
+        "concepts/.*"
+        ".*/test/.*")
     else()
       message(WARNING "Coverage is only supported on linux")
     endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15)
+cmake_minimum_required(VERSION 3.19)
 set(CMAKE_CXX_STANDARD 20)
 
 project(opencmw-cpp CXX)
@@ -7,6 +7,19 @@ include(cmake/PreventInSourceBuilds.cmake)
 include(GNUInstallDirs)
 
 include(cmake/CMakeRC.cmake)
+
+# Check for supported compiler versions
+if(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
+  if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 11.1.0)
+    message(FATAL_ERROR "GCC>=11.1.0 required, but gcc ${CMAKE_CXX_COMPILER_VERSION} detected.")
+  endif()
+elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 13.0.0)
+    message(FATAL_ERROR "Clang>=13.0.0 required, but clang ${CMAKE_CXX_COMPILER_VERSION} detected.")
+  endif()
+else()
+  message(WARN "No version check for your compiler (${CMAKE_CXX_COMPILER_ID}) implemented, in case of build problems consider updating your compiler or check if you can switch to gcc or clang")
+endif()
 
 # Link this 'library' to set the c++ standard / compile-time options requested
 add_library(project_options INTERFACE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,20 +9,18 @@ include(GNUInstallDirs)
 include(cmake/CMakeRC.cmake)
 
 # Check for supported compiler versions
-if(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
-  if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 11.1.0)
-    message(FATAL_ERROR "GCC>=11.1.0 required, but gcc ${CMAKE_CXX_COMPILER_VERSION} detected.")
-  endif()
-elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 13.0.0)
-    message(FATAL_ERROR "Clang>=13.0.0 required, but clang ${CMAKE_CXX_COMPILER_VERSION} detected.")
-  endif()
-else()
-  message(
-    WARN
-    "No version check for your compiler (${CMAKE_CXX_COMPILER_ID}) implemented, in case of build problems consider updating your compiler or check if you can switch to gcc or clang"
-  )
-endif()
+if (CMAKE_CXX_COMPILER_ID MATCHES "GNU")
+    if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 11.1.0)
+        message(FATAL_ERROR "GCC>=11.1.0 required, but gcc ${CMAKE_CXX_COMPILER_VERSION} detected.")
+    endif ()
+elseif (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 13.0.0)
+        message(FATAL_ERROR "Clang>=13.0.0 required, but clang ${CMAKE_CXX_COMPILER_VERSION} detected.")
+    endif ()
+else ()
+    message(WARN "No version check for your compiler (${CMAKE_CXX_COMPILER_ID}) implemented, "
+            "in case of build problems consider updating your compiler or check if you can switch to gcc or clang")
+endif ()
 
 # Link this 'library' to set the c++ standard / compile-time options requested
 add_library(project_options INTERFACE)
@@ -30,12 +28,12 @@ target_include_directories(project_options INTERFACE ${CMAKE_SOURCE_DIR}/3rd_par
 
 target_compile_features(project_options INTERFACE cxx_std_20)
 
-if(CMAKE_CXX_COMPILER_ID MATCHES ".*Clang")
-  option(ENABLE_BUILD_WITH_TIME_TRACE "Enable -ftime-trace to generate time tracing .json files on clang" OFF)
-  if(ENABLE_BUILD_WITH_TIME_TRACE)
-    target_compile_options(project_options INTERFACE -ftime-trace)
-  endif()
-endif()
+if (CMAKE_CXX_COMPILER_ID MATCHES ".*Clang")
+    option(ENABLE_BUILD_WITH_TIME_TRACE "Enable -ftime-trace to generate time tracing .json files on clang" OFF)
+    if (ENABLE_BUILD_WITH_TIME_TRACE)
+        target_compile_options(project_options INTERFACE -ftime-trace)
+    endif ()
+endif ()
 
 # enable cache system
 include(cmake/Cache.cmake)
@@ -58,84 +56,60 @@ enable_doxygen()
 include(cmake/StaticAnalyzers.cmake)
 
 option(ENABLE_TESTING "Enable Test Builds" ON)
-if(CMAKE_BUILD_TYPE STREQUAL "Debug" OR GENERATOR_IS_MULTI_CONFIG)
-  option(ENABLE_COVERAGE "Enable Coverage" ON)
-else()
-  option(ENABLE_COVERAGE "Enable Coverage" OFF)
-endif()
+if (CMAKE_BUILD_TYPE STREQUAL "Debug" OR GENERATOR_IS_MULTI_CONFIG)
+    option(ENABLE_COVERAGE "Enable Coverage" ON)
+else ()
+    option(ENABLE_COVERAGE "Enable Coverage" OFF)
+endif ()
 option(ENABLE_CONCEPTS "Enable Concepts Builds" ON)
 
 # Very basic PCH example
 option(ENABLE_PCH "Enable Precompiled Headers" OFF)
-if(ENABLE_PCH)
-  # This sets a global PCH parameter, each project will build its own PCH, which is a good idea if any #define's change
-  #
-  # consider breaking this out per project as necessary
-  target_precompile_headers(
-    project_options
-    INTERFACE
-    <vector>
-    <string>
-    <map>
-    <utility>)
-endif()
+if (ENABLE_PCH)
+    # This sets a global PCH parameter, each project will build its own PCH, which is a good idea if any #define's change
+    #
+    # consider breaking this out per project as necessary
+    target_precompile_headers(project_options INTERFACE
+            <vector>
+            <string>
+            <map>
+            <utility>)
+endif ()
 
 include(cmake/Conan.cmake)
 run_conan()
 include(cmake/ReflCpp.cmake) # todo: switch to obtaining reflcpp from conan
 
-if(ENABLE_TESTING)
-  enable_testing()
-  message("Building Tests.")
-  if(ENABLE_COVERAGE)
-    if(UNIX AND NOT APPLE) # Linux
-      message("Coverage reporting enabled")
-      include(cmake/CodeCoverage.cmake) # https://github.com/bilke/cmake-modules/blob/master/CodeCoverage.cmake
-                                        # (License: BSL-1.0)
-      target_compile_options(
-        project_options
-        INTERFACE --coverage
-                  -O0
-                  -g
-                  -U_FORTIFY_SOURCE
-                  -D_FORTIFY_SOURCE=0) # fortify_source is not possible without optimization
-      target_link_libraries(project_options INTERFACE --coverage)
-      append_coverage_compiler_flags()
-      setup_target_for_coverage_gcovr_xml(
-        NAME
-        coverage
-        EXECUTABLE
-        ctest
-        DEPENDENCIES
-        core_tests
-        majordomo_tests
-        serialiser_tests
-        EXCLUDE
-        "$CMAKE_BUILD_DIR/*"
-        "concepts/.*"
-        ".*/test/.*")
-      setup_target_for_coverage_gcovr_html(
-        NAME
-        coverage_html
-        EXECUTABLE
-        ctest
-        DEPENDENCIES
-        core_tests
-        majordomo_tests
-        serialiser_tests
-        EXCLUDE
-        "$CMAKE_BUILD_DIR/*"
-        "concepts/.*"
-        ".*/test/.*")
-    else()
-      message(WARNING "Coverage is only supported on linux")
-    endif()
-  endif()
-endif()
+if (ENABLE_TESTING)
+    enable_testing()
+    message("Building Tests.")
+    if (ENABLE_COVERAGE)
+        if (UNIX AND NOT APPLE) # Linux
+            message("Coverage reporting enabled")
+            include(cmake/CodeCoverage.cmake) # https://github.com/bilke/cmake-modules/blob/master/CodeCoverage.cmake
+            # (License: BSL-1.0)
+            target_compile_options(project_options INTERFACE --coverage -O0 -g -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=0) # fortify_source is not possible without optimization
+            target_link_libraries(project_options INTERFACE --coverage)
+            append_coverage_compiler_flags()
+            setup_target_for_coverage_gcovr_xml(
+                    NAME coverage
+                    EXECUTABLE ctest
+                    DEPENDENCIES core_tests majordomo_tests serialiser_tests
+                    EXCLUDE "$CMAKE_BUILD_DIR/*" "concepts/.*" ".*/test/.*")
+            setup_target_for_coverage_gcovr_html(
+                    NAME coverage_html
+                    EXECUTABLE ctest
+                    DEPENDENCIES core_tests majordomo_tests serialiser_tests
+                    EXCLUDE "$CMAKE_BUILD_DIR/*" "concepts/.*" ".*/test/.*")
+        else ()
+            message(WARNING "Coverage is only supported on linux")
+        endif ()
+    endif ()
+endif ()
 
 add_subdirectory(src)
 
-if(ENABLE_CONCEPTS)
-  message("Building Concepts")
-  add_subdirectory(concepts)
-endif()
+if (ENABLE_CONCEPTS)
+    message("Building Concepts")
+    add_subdirectory(concepts)
+endif ()


### PR DESCRIPTION
Bump required cmake version to 3.19, needed for Interface targets with source files.
Add version checks for gcc and clang to `CMakeLists.txt` to make build errors because of old compilers more explicit.
Format CMakeLists.txt with clang-format.