### PR TITLE
Fix json serialisation of nested objects

### DIFF
--- a/src/serialiser/include/IoSerialiserJson.hpp
+++ b/src/serialiser/include/IoSerialiserJson.hpp
@@ -244,9 +244,11 @@ struct FieldHeaderWriter<Json> {
             if (buffer.template at<uint8_t>(buffer.size() - 2) == ',') {
                 // proceeded by value, remove trailing comma
                 buffer.resize(buffer.size() - 2);
+            }
+            if (field.hierarchyDepth == 0) {
                 buffer.put<WITHOUT>("\n}"sv);
             } else {
-                buffer.put('}');
+                buffer.put<WITHOUT>("\n},\n"sv);
             }
             return 0;
         }

--- a/src/serialiser/include/IoSerialiserJson.hpp
+++ b/src/serialiser/include/IoSerialiserJson.hpp
@@ -462,8 +462,8 @@ struct IoSerialiser<Json, T> {
         FieldHeaderWriter<Json>::template put<IoBuffer::WITHOUT>(buffer, memberField, dims);
         memberField.fieldName = "values"sv;
         FieldHeaderWriter<Json>::template put<IoBuffer::WITHOUT>(buffer, memberField, value.elements());
-        memberField.fieldName = ""sv;
-        FieldHeaderWriter<Json>::template put<IoBuffer::WITHOUT>(buffer, memberField, END_MARKER_INST);
+        buffer.resize(buffer.size() - 2); // remove trailing comma
+        buffer.put<opencmw::IoBuffer::MetaInfo::WITHOUT>("\n}\n"sv);
     }
     static void deserialise(IoBuffer &buffer, FieldDescription auto const &field, T &value) {
         using namespace std::string_view_literals;
@@ -511,7 +511,8 @@ requires(is_stringlike<typename T::key_type>) struct IoSerialiser<Json, T> {
             memberField.fieldName = entry.first;
             FieldHeaderWriter<Json>::template put<IoBuffer::WITHOUT>(buffer, memberField, entry.second);
         }
-        FieldHeaderWriter<Json>::template put<IoBuffer::WITHOUT>(buffer, memberField, END_MARKER_INST);
+        buffer.resize(buffer.size() - 2); // remove trailing comma
+        buffer.put<opencmw::IoBuffer::MetaInfo::WITHOUT>("\n}\n"sv);
     }
     static void deserialise(IoBuffer &buffer, FieldDescription auto const &field, T &value) {
         using namespace std::string_view_literals;

--- a/src/serialiser/test/IoSerialiserJson_tests.cpp
+++ b/src/serialiser/test/IoSerialiserJson_tests.cpp
@@ -67,7 +67,7 @@ TEST_CASE("JsonSerialiserRegressions", "[JsonSerialiser]") {
     opencmw::IoBuffer buffer;
     auto              foo = ReproduceMissingCommaAfterNestedObject{ SimpleInner{ 2.3, "test", { 4, 2 } }, "bar", "baz" };
     opencmw::serialise<opencmw::Json>(buffer, foo);
-    auto expected = R"""("ReproduceMissingCommaAfterNestedObject": {
+    auto expected = R"""("opencmw::ioserialiser_json_tests::ReproduceMissingCommaAfterNestedObject": {
 "a": {
 "val1": 2.3e+00,
 "val2": "test",

--- a/src/serialiser/test/IoSerialiserJson_tests.cpp
+++ b/src/serialiser/test/IoSerialiserJson_tests.cpp
@@ -59,7 +59,7 @@ struct ReproduceMissingCommaAfterNestedObject {
     std::string b;
     std::string c;
 };
-}
+} // namespace opencmw::ioserialiser_json_tests
 ENABLE_REFLECTION_FOR(opencmw::ioserialiser_json_tests::ReproduceMissingCommaAfterNestedObject, a, b, c)
 
 TEST_CASE("JsonSerialiserRegressions", "[JsonSerialiser]") {

--- a/src/serialiser/test/IoSerialiserJson_tests.cpp
+++ b/src/serialiser/test/IoSerialiserJson_tests.cpp
@@ -53,6 +53,32 @@ struct Simple {
 };
 ENABLE_REFLECTION_FOR(Simple, float1, int1, test)
 
+namespace opencmw::ioserialiser_json_tests {
+struct ReproduceMissingCommaAfterNestedObject {
+    SimpleInner a;
+    std::string b;
+    std::string c;
+};
+}
+ENABLE_REFLECTION_FOR(opencmw::ioserialiser_json_tests::ReproduceMissingCommaAfterNestedObject, a, b, c)
+
+TEST_CASE("JsonSerialiserRegressions", "[JsonSerialiser]") {
+    using namespace ioserialiser_json_tests;
+    opencmw::IoBuffer buffer;
+    auto              foo = ReproduceMissingCommaAfterNestedObject{ SimpleInner{ 2.3, "test", { 4, 2 } }, "bar", "baz" };
+    opencmw::serialise<opencmw::Json>(buffer, foo);
+    auto expected = R"""("ReproduceMissingCommaAfterNestedObject": {
+"a": {
+"val1": 2.3e+00,
+"val2": "test",
+"intArray": [4, 2]
+},
+"b": "bar",
+"c": "baz"
+})""";
+    REQUIRE(buffer.asString() == expected);
+}
+
 TEST_CASE("JsonDeserialisation", "[JsonSerialiser]") {
     opencmw::debug::resetStats();
     {


### PR DESCRIPTION
This fixes a serialisation error discovered by @frankosterfeld. Nested objects which where not at the end of the class would lead to malformed json because the comma after the object was not added.