### PR TITLE
Fix DNS handling

### DIFF
--- a/concepts/majordomo/MajordomoRest_example.cpp
+++ b/concepts/majordomo/MajordomoRest_example.cpp
@@ -244,7 +244,7 @@ int main() {
     });
 
     // second broker to test DNS functionalities
-    Broker       secondaryBroker("SecondaryTestBroker", { .dnsAddress = *brokerRouterAddress });
+    Broker       secondaryBroker("SecondaryTestBroker", { .dnsAddress = brokerRouterAddress->str });
 
     std::jthread secondaryBrokerThread([&secondaryBroker] {
         secondaryBroker.run();

--- a/src/majordomo/include/majordomo/RestBackend.hpp
+++ b/src/majordomo/include/majordomo/RestBackend.hpp
@@ -90,10 +90,10 @@ struct PLAIN_HTTP {
 template<typename Mode, typename VirtualFS, role... Roles>
 class RestBackend : public Mode {
 protected:
-    const Broker<Roles...> &_broker;
-    const VirtualFS        &_vfs;
-    std::jthread            _thread;
-    URI<>                   _restAddress;
+    Broker<Roles...> &_broker;
+    const VirtualFS  &_vfs;
+    std::jthread      _thread;
+    URI<>             _restAddress;
 
     using Mode::_svr;
     using Mode::DEFAULT_REST_SCHEME;
@@ -168,8 +168,9 @@ protected:
     }
 
 public:
-    explicit RestBackend(const Broker<Roles...> &broker, const VirtualFS &vfs, URI<> restAddress = URI<>::factory().scheme(DEFAULT_REST_SCHEME).hostName("0.0.0.0").port(DEFAULT_REST_PORT).build())
+    explicit RestBackend(Broker<Roles...> &broker, const VirtualFS &vfs, URI<> restAddress = URI<>::factory().scheme(DEFAULT_REST_SCHEME).hostName("0.0.0.0").port(DEFAULT_REST_PORT).build())
         : _broker(broker), _vfs(vfs), _restAddress(restAddress) {
+        _broker.registerDnsAddress(restAddress);
         _thread = std::jthread(&RestBackend::run, this);
     }
 

--- a/src/majordomo/include/majordomo/Settings.hpp
+++ b/src/majordomo/include/majordomo/Settings.hpp
@@ -14,8 +14,8 @@ struct Settings {
 
     // broker
     std::chrono::milliseconds clientTimeout = std::chrono::seconds(10);
-    opencmw::URI<>            dnsAddress    = opencmw::URI<>("");
-    std::chrono::milliseconds dnsTimeout    = std::chrono::seconds(10);
+    std::string               dnsAddress;
+    std::chrono::milliseconds dnsTimeout = std::chrono::seconds(10);
 
     // worker
     std::chrono::milliseconds workerReconnectInterval = std::chrono::milliseconds(2500);

--- a/src/majordomo/test/helpers.hpp
+++ b/src/majordomo/test/helpers.hpp
@@ -38,6 +38,7 @@ struct RunInThread {
 inline opencmw::majordomo::Settings testSettings() {
     opencmw::majordomo::Settings settings;
     settings.heartbeatInterval = std::chrono::milliseconds(100);
+    settings.dnsTimeout        = std::chrono::milliseconds(250);
     return settings;
 }
 


### PR DESCRIPTION
The forwarding of service names to another broker (via "dnsAddress")
did not work at all. Also clean up the DNS entries and make their
order predictable, for better testability.

Improve the test to cover more of the DNS logic.