### PR TITLE
Suppress compiler warnings for dependent header only libraries

### DIFF
--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -26,8 +26,6 @@ FetchContent_Declare(
         gsl-lite
         GIT_REPOSITORY https://github.com/gsl-lite/gsl-lite.git
         GIT_TAG v0.40.0
-        # including gsl-lite produces some warnings, has to be fixed upstream
-        # upstream fix see https://github.com/gsl-lite/gsl-lite/issues/325 and https://github.com/gsl-lite/gsl-lite/pull/321
         )
 
 # prefers usage via conan, but cmake should work, but doesn't find gsl-lite in targets

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -89,9 +89,6 @@ FetchContent_Declare(
     rxcpp
     GIT_REPOSITORY https://github.com/ReactiveX/RxCpp
     GIT_TAG        7f97aa901701343593869acad1ee5a02292f39cf # TODO Change to the latest tested release of RxCpp before making a release of OpenCMW
-    # Silence warnings when using rxcpp by exporting the header directories as system includes
-    # see upstream issue: https://github.com/ReactiveX/RxCpp/pull/580
-    PATCH_COMMAND sed -e "s%target_include_directories(rxcpp INTERFACE%target_include_directories(rxcpp SYSTEM INTERFACE%" -i projects/CMake/CMakeLists.txt
 )
 FetchContent_MakeAvailable(rxcpp)
 

--- a/src/core/include/TimingCtx.hpp
+++ b/src/core/include/TimingCtx.hpp
@@ -10,9 +10,12 @@
 #include <string_view>
 
 #include <fmt/format.h>
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wuseless-cast" // suppress warning caused by gsl-lite: https://github.com/gsl-lite/gsl-lite/issues/325
 #include <units/chrono.h>
 #include <units/isq/dimensions/time.h>
 #include <units/isq/si/time.h>
+#pragma GCC diagnostic pop
 
 namespace opencmw {
 

--- a/src/core/include/opencmw.hpp
+++ b/src/core/include/opencmw.hpp
@@ -13,9 +13,12 @@
 #include <fmt/ostream.h>
 #include <fmt/ranges.h>
 #include <refl.hpp>
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wuseless-cast" // suppress warning caused by gsl-lite: https://github.com/gsl-lite/gsl-lite/issues/325
 #include <units/concepts.h>
 #include <units/quantity.h>
 #include <units/quantity_io.h>
+#pragma GCC diagnostic pop
 
 #define FWD(x) std::forward<decltype(x)>(x)               // short-hand notation
 #define forceinline inline __attribute__((always_inline)) // use this for hot-spots only <-> may bloat code size, not fit into cache and consequently slow down execution

--- a/src/disruptor/include/disruptor/Rx.hpp
+++ b/src/disruptor/include/disruptor/Rx.hpp
@@ -2,7 +2,13 @@
 
 #include <optional>
 
+#pragma gcc diagnostic push
+#pragma GCC diagnostic ignored "-Wshadow"
+#pragma GCC diagnostic ignored "-Wuseless-cast"
+#pragma GCC diagnostic ignored "-Wold-style-cast"
+#pragma GCC diagnostic ignored "-Wsign-conversion"
 #include <rxcpp/rx.hpp>
+#pragma GCC diagnostic pop
 
 #include <disruptor/Disruptor.hpp>
 

--- a/src/majordomo/include/majordomo/RestBackend.hpp
+++ b/src/majordomo/include/majordomo/RestBackend.hpp
@@ -14,7 +14,6 @@
 #pragma GCC diagnostic ignored "-Wuninitialized"
 #pragma GCC diagnostic ignored "-Wuseless-cast"
 #define CPPHTTPLIB_THREAD_POOL_COUNT 8
-#define CPPHTTPLIB_OPENSSL_SUPPORT
 #include <httplib.h>
 #pragma GCC diagnostic pop
 

--- a/src/serialiser/test/IoSerialiserJson_tests.cpp
+++ b/src/serialiser/test/IoSerialiserJson_tests.cpp
@@ -6,8 +6,11 @@
 #include <iostream>
 #include <string_view>
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wuseless-cast" // suppress warning caused by gsl-lite: https://github.com/gsl-lite/gsl-lite/issues/325
 #include <units/isq/si/length.h>
 #include <units/isq/si/speed.h>
+#pragma GCC diagnostic pop
 
 #include <Debug.hpp>
 #include <IoSerialiserJson.hpp>

--- a/src/serialiser/test/IoSerialiserYAML_tests.cpp
+++ b/src/serialiser/test/IoSerialiserYAML_tests.cpp
@@ -4,11 +4,14 @@
 #include <iostream>
 #include <string_view>
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wuseless-cast" // suppress warning caused by gsl-lite: https://github.com/gsl-lite/gsl-lite/issues/325
 #include <units/isq/si/energy.h>
 #include <units/isq/si/length.h>
 #include <units/isq/si/mass.h>
 #include <units/isq/si/resistance.h>
 #include <units/isq/si/time.h>
+#pragma GCC diagnostic pop
 
 #include <Debug.hpp>
 #include <IoSerialiserYAML.hpp>

--- a/src/serialiser/test/IoSerialiserYaS_tests.cpp
+++ b/src/serialiser/test/IoSerialiserYaS_tests.cpp
@@ -8,6 +8,8 @@
 #include <opencmw.hpp>
 #include <string_view>
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wuseless-cast" // suppress warning caused by gsl-lite: https://github.com/gsl-lite/gsl-lite/issues/325
 #include <units/isq/si/electric_current.h>
 #include <units/isq/si/energy.h>
 #include <units/isq/si/length.h>
@@ -15,6 +17,7 @@
 #include <units/isq/si/resistance.h>
 #include <units/isq/si/speed.h>
 #include <units/isq/si/time.h>
+#pragma GCC diagnostic pop
 
 #include <Debug.hpp>
 #include <IoSerialiserYaS.hpp>

--- a/src/serialiser/test/Utils_tests.cpp
+++ b/src/serialiser/test/Utils_tests.cpp
@@ -7,6 +7,8 @@
 #include <iostream>
 #include <string_view>
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wuseless-cast" // suppress warning caused by gsl-lite: https://github.com/gsl-lite/gsl-lite/issues/325
 #include <units/isq/si/electric_current.h>
 #include <units/isq/si/energy.h>
 #include <units/isq/si/length.h>
@@ -14,6 +16,7 @@
 #include <units/isq/si/resistance.h>
 #include <units/isq/si/speed.h>
 #include <units/isq/si/time.h>
+#pragma GCC diagnostic pop
 
 #include <Debug.hpp>
 #include <IoSerialiser.hpp>


### PR DESCRIPTION
Suppress compiler warnings for header only libraries by wrapping their include in with a `#pragma diagnostic push/pop`.  The cause of these warnings cannot be fixed on our side, so we have to wait for upstream to fix them. This is more verbose than using the cmake `SYSTEM` keyword to add them to `-Isystem` which can hide real bugs and has other side effects. Since `gsl-lite` is a dependency of `mp-units`, the suppression has to be added around every header inclusion of mp-units.