### PR TITLE
Improve build/example section of README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,23 +90,7 @@ Note that building from source is only required if you want to modify opencmw-cp
 If you only want to make use of opencmw-cpp in your project to implement a service, it is not required to clone/build opencmw-cpp.
 In that case, rather take a look at the project [opencmw-cpp-example](https://github.com/alexxcons/opencmw-cpp-example), which demonstrates how a simple, first service can be implemented.
 
-
-Building on linux operating systems:
-
-```
-git clone https://github.com/alexxcons/opencmw-cpp.git
-cd opencmw-cpp
-mkdir build
-ccmake -S . -B ./build
-```
-* press 'c' and wait until 'configure' is done, check for errors and try to install missing dependencies
-* If there are no errors, press 'g' and wait until 'generate' is done and start the build:
-
-```
-cmake --build ./build
-```
-
-For detailed, advanced options or installation on non-linux operating systems, please check the [detailed build instructions](docs/BuildInstructions.md).
+For concrete build instructions, please check the [build instructions page](docs/BuildInstructions.md).
 
 ### Example
 

--- a/docs/BuildInstructions.md
+++ b/docs/BuildInstructions.md
@@ -1,4 +1,37 @@
-## Build Instructions
+# Build Instructions
+
+## Simplified build and test
+
+Simplified build steps to checkout and build the project on linux operating systems:
+
+``` bash
+git clone https://github.com/fair-acc/opencmw-cpp.git
+cd opencmw-cpp
+mkdir build; cd build
+cmake .. -DCMAKE_BUILD_TYPE=Release # for debug builds use 'Debug'
+make -j 4
+```
+
+Now you can run all tests with:
+
+
+``` bash
+ctest
+```
+
+There are as well various samples inside `concepts/<core|cmrc|disruptor|majordomo|serialiser>` which can be executed: 
+
+
+``` bash
+./concepts/core/collection_example
+./concepts/core/URI_example
+./concepts/cmrc/cmrc_example
+...
+```
+
+## Advanced build options
+
+The steps below will show how various configuration and build options can be used.
 
 ### Build directory
 


### PR DESCRIPTION
- Simple build instruction, with reference to more advanced options
- Make clear that building opencmw-cpp itself is not required when the
intention is, to create a new service
- Reference to opencmw-cpp-example instead of Java example