### PR TITLE
basic thread pool that can optionally grow/shrink between [min, max] number of threads

### DIFF
--- a/concepts/core/BasicThreadPool_example.cpp
+++ b/concepts/core/BasicThreadPool_example.cpp
@@ -1,0 +1,74 @@
+#include <atomic>
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-nonliteral" // suppress warning caused by format not a string literal, format string not checked
+#include <fmt/chrono.h>
+#include <fmt/format.h>
+#pragma GCC diagnostic pop
+
+#include <ThreadPool.hpp>
+
+int main() {
+    using namespace std::chrono;
+
+    opencmw::BasicThreadPool<opencmw::CPU_BOUND> poolWork("CustomIOPool", 1, 1);  // pool for CPU-bound tasks with exactly 1 thread
+    opencmw::BasicThreadPool<opencmw::IO_BOUND>  poolIO("CustomIOPool", 1, 1000); // pool for IO-bound (potentially blocking) tasks with at least 1 and a max of 1000 threads
+    poolIO.keepAliveDuration() = seconds(10);                                     // keeps idling threads alive for 10 seconds
+    poolIO.waitUntilInitialised();                                                // wait until the pool is initialised (optional)
+    assert(poolIO.isInitialised());                                               // check if the pool is initialised
+
+    // enqueue and add task to list
+    poolIO.execute([] { fmt::print("Hello World from thread '{}'!\n", opencmw::thread::getThreadName()); });
+
+    constexpr int nTestRun = 5;
+    constexpr int nTasks   = 100;
+    for (int testRun = 0; testRun < nTestRun; testRun++) {
+        // enqueue nTasks tasks on 1 threads -> the other tasks will need to wait until threads becomes available
+        const auto       start = steady_clock::now();
+        std::atomic<int> counter(0);
+        for (int i = 0; i < nTasks; i++) {
+            poolWork.execute([&counter] { std::this_thread::sleep_for(milliseconds(10)); ++counter; counter.notify_one(); });
+        }
+        auto const diff1 = steady_clock::now() - start;
+        while (std::atomic_load(&counter) < nTasks)
+            ; // wait until all tasks are finished
+        auto const diff2 = steady_clock::now() - start;
+        fmt::print("run {}: {:12} -- dispatching took {:>7} -- execution took {:>7} - #threads: {}\n", testRun, "CPU-bound",
+                duration_cast<microseconds>(diff1), duration_cast<milliseconds>(diff2), poolWork.numThreads());
+    }
+
+    for (int testRun = 0; testRun < nTestRun; testRun++) {
+        // execute nTasks tasks on up to 100 threads
+        const auto       start = steady_clock::now();
+        std::atomic<int> counter(0);
+        for (int i = 0; i < nTasks; i++) {
+            poolIO.execute([&counter] { std::this_thread::sleep_for(milliseconds(10)); ++counter; counter.notify_one(); });
+        }
+        auto const diff1 = steady_clock::now() - start;
+        while (std::atomic_load(&counter) < nTasks)
+            ; // wait until all tasks are finished
+        auto const diff2 = steady_clock::now() - start;
+        std::this_thread::sleep_for(milliseconds(10));
+        fmt::print("run {}: {:12} -- dispatching took {:>7} -- execution took {:>7} - #threads: {}\n", testRun, "IO-bound",
+                duration_cast<microseconds>(diff1), duration_cast<milliseconds>(diff2), poolIO.numThreads());
+    }
+
+    for (int testRun = 0; testRun < nTestRun; testRun++) {
+        // execute nTasks tasks, each on a new jthreads (N.B. worst case timing <-> base-line benchmark)
+        const auto                start = steady_clock::now();
+        std::atomic<int>          counter(0);
+        std::vector<std::jthread> threads;
+        for (int i = 0; i < nTasks; i++) {
+            threads.emplace_back([&counter] { std::this_thread::sleep_for(milliseconds(10)); ++counter; counter.notify_one(); });
+        }
+        auto const diff1 = steady_clock::now() - start;
+        while (std::atomic_load(&counter) < nTasks)
+            ; // wait until all tasks are finished
+        auto const diff2 = steady_clock::now() - start;
+        std::this_thread::sleep_for(milliseconds(10));
+        fmt::print("run {}: {:12} -- dispatching took {:>7} -- execution took {:>7} - #threads: {}\n", testRun, "bare-thread",
+                duration_cast<microseconds>(diff1), duration_cast<milliseconds>(diff2), nTasks);
+    }
+
+    poolWork.requestShutdown();
+    poolIO.requestShutdown(); // request the pool to shutdown
+}

--- a/concepts/core/CMakeLists.txt
+++ b/concepts/core/CMakeLists.txt
@@ -1,3 +1,6 @@
+add_executable(BasicThreadPool_example BasicThreadPool_example.cpp)
+target_link_libraries(BasicThreadPool_example PRIVATE core opencmw_project_options opencmw_project_warnings)
+
 add_executable(collection_example collection_example.cpp)
 target_link_libraries(collection_example PRIVATE core opencmw_project_options opencmw_project_warnings)
 

--- a/src/core/include/ThreadPool.hpp
+++ b/src/core/include/ThreadPool.hpp
@@ -1,0 +1,381 @@
+#ifndef OPENCMW_CPP_THREADPOOL_HPP
+#define OPENCMW_CPP_THREADPOOL_HPP
+
+#include <atomic>
+#include <cassert>
+#include <chrono>
+#include <condition_variable>
+#include <list>
+#include <mutex>
+#include <span>
+#include <string>
+#include <thread>
+
+#include <fmt/format.h>
+
+#include <SpinWait.hpp>
+#include <ThreadAffinity.hpp>
+
+namespace opencmw {
+
+namespace thread_pool::detail {
+struct Task {
+    uint64_t              id;
+    std::function<void()> func;
+    Task                 *next = nullptr;
+    Task                 *self = this;
+    bool                  operator==(const Task &other) const { return self == other.self; }
+};
+
+class TaskQueue {
+    mutable AtomicMutex<> _lock;
+    Task                 *_head = nullptr;
+    Task                 *_tail = nullptr;
+    uint32_t              _size = 0;
+
+public:
+    TaskQueue()                       = default;
+    TaskQueue(const TaskQueue &queue) = delete;
+    TaskQueue &operator=(const TaskQueue &queue) = delete;
+    ~TaskQueue() { clear(); }
+
+    template<bool lock = true>
+    uint32_t clear() {
+        if constexpr (lock) {
+            _lock.lock();
+        }
+        const uint32_t res = _size;
+        for (Task *job = pop<false>(); job != nullptr; job = pop<false>()) {
+            delete job;
+        }
+        assert(_size == 0 && "TaskQueue::clear() failed");
+        if constexpr (lock) {
+            _lock.unlock();
+        }
+        return res;
+    }
+
+    uint32_t size() const {
+        std::scoped_lock lock(_lock);
+        return _size;
+    }
+
+    template<bool lock = true>
+    void push(Task *job) {
+        if constexpr (lock) {
+            _lock.lock();
+        }
+        job->next = nullptr;
+        if (_head == nullptr) {
+            _head = job;
+        }
+        if (_tail == nullptr) {
+            _tail = job;
+        } else {
+            _tail->next = job;
+            _tail       = job;
+        }
+        _size++;
+        if constexpr (lock) {
+            _lock.unlock();
+        }
+    };
+
+    template<bool lock = true>
+    Task *pop() {
+        if constexpr (lock) {
+            _lock.lock();
+        }
+        Task *head = _head;
+        if (head != nullptr) {
+            _head = head->next;
+            _size--;
+            if (head == _tail) {
+                _tail = nullptr;
+            }
+        }
+        if constexpr (lock) {
+            _lock.unlock();
+        }
+        return head;
+    };
+};
+
+} // namespace thread_pool::detail
+
+enum TaskType {
+    IO_BOUND  = 0,
+    CPU_BOUND = 1
+};
+
+template<typename T>
+concept ThreadPool = requires(T t, std::function<void()> &&func) {
+    { t.execute(std::move(func)) } -> std::same_as<void>;
+};
+
+/**
+ * <h2>Basic thread pool that uses a fixed-number or optionally grow/shrink between a [min, max] number of threads.</h2>
+ * The growth policy is controlled by the TaskType template parameter:
+ * <ol type="A">
+ *   <li> <code>TaskType::IO_BOUND</code> if the task is IO bound, i.e. it is likely to block the thread for a long time, or
+ *   <li> <code>TaskType::CPU_BOUND</code> if the task is CPU bound, i.e. it is primarily limited by the CPU and memory bandwidth.
+ * </ol>
+ * <br>
+ * For the IO_BOUND policy, unused threads are kept alive for a pre-defined amount of time to be reused and gracefully
+ * shut down to the minimum number of threads when unused.
+ * <br>
+ * For the CPU_BOUND policy, the threads are equally spread and pinned across the set CPU affinity.
+ * <br>
+ * The CPU affinity and OS scheduling policy and priorities are controlled by:
+ * <ul>
+ *  <li> <code>setAffinityMask(std::vector&lt;bool&gt; threadAffinityMask);</code> </li>
+ *  <li> <code>setThreadSchedulingPolicy(const thread::Policy schedulingPolicy, const int schedulingPriority)</code> </li>
+ * </ul>
+ */
+template<TaskType taskType>
+class BasicThreadPool {
+    using Task      = thread_pool::detail::Task;
+    using TaskQueue = thread_pool::detail::TaskQueue;
+    static std::atomic<uint64_t> _globalPoolId;
+    static std::atomic<uint64_t> _taskID;
+    static std::string           getName() { return fmt::format("BasicThreadPool#{}", _globalPoolId.fetch_add(1)); }
+
+    std::atomic<bool>            _initialised = ATOMIC_FLAG_INIT;
+    bool                         _shutdown    = { false };
+
+    std::condition_variable      _condition;
+    TaskQueue                    _taskQueue;
+    std::atomic<std::size_t>     _numTaskedQueued{ 0U };
+    std::atomic<std::size_t>     _numTasksRunning{ 0U };
+    TaskQueue                    _recycledTasks;
+
+    std::mutex                   _threadListMutex{};
+    std::atomic<std::size_t>     _numThreads{ 0U };
+    std::list<std::jthread>      _threads;
+
+    std::vector<bool>            _affinityMask{};
+    thread::Policy               _schedulingPolicy   = thread::Policy::OTHER;
+    int                          _schedulingPriority = 0;
+
+    const std::string            _poolName;
+    const uint32_t               _minThreads;
+    const uint32_t               _maxThreads;
+    std::chrono::microseconds    _sleepDuration       = std::chrono::milliseconds(1);
+    std::chrono::seconds         _keepAliveDurationIO = std::chrono::seconds(10);
+
+public:
+    BasicThreadPool()
+        : BasicThreadPool(getName(), std::thread::hardware_concurrency(), std::thread::hardware_concurrency()) {}
+    BasicThreadPool(std::string_view name, uint32_t min, uint32_t max)
+        : _poolName(name), _minThreads(min), _maxThreads(max) {
+        assert(min > 0 && "minimum number of threads must be > 0");
+        assert(min <= max && "minimum number of threads must be <= maximum number of threads");
+        for (uint32_t i = 0; i < _minThreads; ++i) {
+            createWorkerThread();
+        }
+    }
+
+    ~BasicThreadPool() {
+        _shutdown = true;
+        _condition.notify_all();
+        while (_numThreads > 0) {
+            std::this_thread::sleep_for(_sleepDuration);
+        }
+        _recycledTasks.clear();
+        [[maybe_unused]] const auto queueSize = _taskQueue.clear();
+        assert(queueSize == 0 && "task queue not empty");
+    }
+    BasicThreadPool(const BasicThreadPool &) = delete;
+    BasicThreadPool(BasicThreadPool &&)      = delete;
+    BasicThreadPool           &operator=(const BasicThreadPool &) = delete;
+    BasicThreadPool           &operator=(BasicThreadPool &&) = delete;
+
+    [[nodiscard]] std::string  poolName() const noexcept { return _poolName; }
+    [[nodiscard]] uint32_t     minThreads() const noexcept { return _minThreads; };
+    [[nodiscard]] uint32_t     maxThreads() const noexcept { return _maxThreads; };
+
+    [[nodiscard]] std::size_t  numThreads() const noexcept { return std::atomic_load_explicit(&_numThreads, std::memory_order_acquire); }
+    [[nodiscard]] std::size_t  numTasksRunning() const noexcept { return std::atomic_load_explicit(&_numTasksRunning, std::memory_order_acquire); }
+    [[nodiscard]] std::size_t  numTasksQueued() const { return std::atomic_load_explicit(&_numTaskedQueued, std::memory_order_acquire); }
+    [[nodiscard]] std::size_t  numTasksRecycled() const { return _recycledTasks.size(); }
+    std::chrono::microseconds &sleepDuration() noexcept { return _sleepDuration; }
+    std::chrono::seconds      &keepAliveDuration() noexcept { return _keepAliveDurationIO; }
+    [[nodiscard]] bool         isInitialised() const { return _initialised.load(std::memory_order::acquire); }
+    void                       waitUntilInitialised() const { _initialised.wait(false); }
+    void                       requestShutdown() {
+        _shutdown = true;
+        _condition.notify_all();
+    }
+    [[nodiscard]] bool isShutdown() const { return _shutdown; }
+
+    //
+
+    [[nodiscard]] std::vector<bool> getAffinityMask() const { return _affinityMask; }
+
+    void                            setAffinityMask(const std::vector<bool> &threadAffinityMask) {
+        _affinityMask.clear();
+        std::ranges::copy(threadAffinityMask, std::back_inserter(_affinityMask));
+        cleanupFinishedThreads();
+        updateThreadConstraints();
+    }
+
+    [[nodiscard]] auto getSchedulingPolicy() const { return _schedulingPolicy; }
+
+    [[nodiscard]] auto getSchedulingPriority() const { return _schedulingPriority; }
+
+    void               setThreadSchedulingPolicy(const thread::Policy schedulingPolicy = thread::Policy::OTHER, const int schedulingPriority = 0) {
+        _schedulingPolicy   = schedulingPolicy;
+        _schedulingPriority = schedulingPriority;
+        cleanupFinishedThreads();
+        updateThreadConstraints();
+    }
+
+    void execute(std::function<void()> &&func) {
+        static thread_local SpinWait spinWait;
+        std::atomic_fetch_add(&_numTaskedQueued, 1U);
+        _taskQueue.push(createTask(std::move(func)));
+        _condition.notify_one();
+        if constexpr (taskType == TaskType::IO_BOUND) {
+            _condition.notify_one();
+            spinWait.spinOnce();
+            spinWait.spinOnce();
+            while (_taskQueue.size() > 0) {
+                if (const auto nThreads = numThreads(); nThreads <= numTasksRunning() && nThreads <= _maxThreads) {
+                    createWorkerThread();
+                }
+            }
+            spinWait.reset();
+        }
+    }
+
+private:
+    void cleanupFinishedThreads() {
+        std::scoped_lock lock(_threadListMutex);
+        std::erase_if(_threads, [](auto &thread) { return !thread.joinable(); });
+    }
+
+    void updateThreadConstraints() {
+        std::size_t      threadID = 0;
+        std::scoped_lock lock(_threadListMutex);
+        std::erase_if(_threads, [](auto &thread) { return !thread.joinable(); });
+        std::ranges::for_each(_threads, [&](auto &thread) { updateThreadConstraints(threadID++, thread); });
+    }
+
+    void updateThreadConstraints(const std::size_t threadID, std::jthread &thread) const {
+        thread::setThreadName(fmt::format("{}#{}", _poolName, threadID), thread);
+        thread::setThreadSchedulingParameter(_schedulingPolicy, _schedulingPriority, thread);
+        if (!_affinityMask.empty()) {
+            if (taskType == TaskType::IO_BOUND) {
+                thread::setThreadAffinity(_affinityMask);
+                return;
+            }
+            const std::vector<bool> affinityMask = distributeThreadAffinityAcrossCores(_affinityMask, threadID);
+            std::cout << fmt::format("{}#{} affinity mask: {}", _poolName, threadID, fmt::join(affinityMask, ",")) << std::endl;
+            thread::setThreadAffinity(affinityMask);
+        }
+    }
+
+    std::vector<bool> distributeThreadAffinityAcrossCores(const std::vector<bool> &globalAffinityMask, const std::size_t threadID) const {
+        if (globalAffinityMask.empty()) {
+            return {};
+        }
+        std::vector<bool> affinityMask;
+        int               coreCount = 0;
+        for (bool value : globalAffinityMask) {
+            if (value) {
+                affinityMask.push_back(coreCount++ % _minThreads == threadID);
+            } else {
+                affinityMask.push_back(false);
+            }
+        }
+        return affinityMask;
+    }
+
+    void createWorkerThread() {
+        std::scoped_lock  lock(_threadListMutex);
+        const std::size_t nThreads = numThreads();
+        std::jthread     &thread   = _threads.emplace_back(&BasicThreadPool::worker, this);
+        updateThreadConstraints(nThreads + 1, thread);
+        _numThreads.wait(nThreads);
+    }
+
+    Task *createTask(std::function<void()> &&func) {
+        Task *task = _recycledTasks.pop();
+        if (task == nullptr) {
+            task = new Task{ std::atomic_fetch_add(&_taskID, 1U) + 1U, std::move(func) };
+        } else {
+            task->id   = std::atomic_fetch_add(&_taskID, 1U) + 1U;
+            task->func = std::move(func);
+        }
+        return task;
+    }
+
+    bool popTask(Task *&task) {
+        task = _taskQueue.pop();
+        if (task == nullptr) {
+            return false;
+        }
+        std::atomic_fetch_sub(&_numTaskedQueued, 1U);
+        return true;
+    }
+
+    void worker() {
+        constexpr uint32_t N_SPIN       = 1 << 8;
+        uint32_t           noop_counter = 0;
+        std::atomic_fetch_add(&_numThreads, 1);
+        std::mutex       mutex;
+        std::unique_lock lock(mutex);
+        auto             lastUsed              = std::chrono::steady_clock::now();
+        auto             timeDiffSinceLastUsed = std::chrono::steady_clock::now() - lastUsed;
+        Task            *currentTask           = nullptr;
+        if (numThreads() >= _minThreads) {
+            std::atomic_store_explicit(&_initialised, true, std::memory_order_release);
+            _initialised.notify_all();
+        }
+        _numThreads.notify_one();
+        do {
+            if (popTask(currentTask)) {
+                std::atomic_fetch_add(&_numTasksRunning, 1);
+                currentTask->func();
+                std::atomic_fetch_sub(&_numTasksRunning, 1);
+                lastUsed = std::chrono::steady_clock::now();
+                _recycledTasks.push(currentTask);
+                noop_counter = 0;
+            } else if (++noop_counter > N_SPIN) [[unlikely]] {
+                // perform some thread maintenance tasks before going to sleep
+                noop_counter = noop_counter / 2;
+                cleanupFinishedThreads();
+
+                _condition.wait_for(lock, _keepAliveDurationIO, [this] { return numTasksQueued() > 0 || isShutdown(); });
+            }
+            timeDiffSinceLastUsed = std::chrono::steady_clock::now() - lastUsed;
+        } while (!isShutdown() && (numThreads() <= _minThreads || timeDiffSinceLastUsed < _keepAliveDurationIO));
+        auto nThread = std::atomic_fetch_sub(&_numThreads, 1);
+        _numThreads.notify_all();
+
+        if (nThread == 1) {
+            // cleanup
+            _recycledTasks.clear();
+            [[maybe_unused]] const auto queueSize = _taskQueue.clear();
+            assert(queueSize == 0 && "task queue not empty");
+        }
+    }
+
+    void sleepOrYield() const {
+        if (_sleepDuration.count() > 0) {
+            std::this_thread::sleep_for(_sleepDuration);
+        } else {
+            std::this_thread::yield();
+        }
+    }
+};
+template<TaskType T>
+inline std::atomic<uint64_t> BasicThreadPool<T>::_globalPoolId = 0U;
+template<TaskType T>
+inline std::atomic<uint64_t> BasicThreadPool<T>::_taskID = 0U;
+static_assert(ThreadPool<opencmw::BasicThreadPool<IO_BOUND>>);
+static_assert(ThreadPool<opencmw::BasicThreadPool<CPU_BOUND>>);
+
+} /* namespace opencmw */
+
+#endif // OPENCMW_CPP_THREADPOOL_HPP

--- a/src/core/test/CMakeLists.txt
+++ b/src/core/test/CMakeLists.txt
@@ -1,6 +1,6 @@
 include(CTest)
 include(Catch)
-add_executable(core_tests catch_main.cpp 00_opencmw_basic_tests.cpp collection_tests.cpp URI_tests.cpp MIME_tests.cpp ReaderWriterLock_tests.cpp SpinWait_tests.cpp TimingCtx_tests.cpp ThreadAffinity_tests.cpp)
+add_executable(core_tests catch_main.cpp 00_opencmw_basic_tests.cpp collection_tests.cpp URI_tests.cpp MIME_tests.cpp ReaderWriterLock_tests.cpp SpinWait_tests.cpp TimingCtx_tests.cpp ThreadAffinity_tests.cpp ThreadPool_tests.cpp)
 target_link_libraries(core_tests PUBLIC opencmw_project_warnings opencmw_project_options Catch2::Catch2 core pthread)
 # automatically discover tests that are defined in catch based test files you can modify the unittests. Set TEST_PREFIX to whatever you want, or use different for different binaries
 # catch_discover_tests(core_tests TEST_PREFIX  "unittests." REPORTER xml OUTPUT_DIR . OUTPUT_PREFIX "unittests." OUTPUT_SUFFIX .xml)

--- a/src/core/test/SpinWait_tests.cpp
+++ b/src/core/test/SpinWait_tests.cpp
@@ -29,3 +29,16 @@ TEST_CASE("SpinWait basic tests", "[SpinWait]") {
     REQUIRE(waiter.spinUntil(validate, 10));
     REQUIRE(!waiter.spinUntil([]() noexcept -> bool { return false; }, 0));
 }
+
+TEST_CASE("AtomicMutex basic tests", "[AtomicMutex]") {
+    using namespace opencmw;
+    opencmw::AtomicMutex<NO_SPIN_WAIT> mutex1;
+    REQUIRE_NOTHROW(mutex1.lock());
+    REQUIRE_NOTHROW(mutex1.unlock());
+
+    opencmw::AtomicMutex<SpinWait<10, 5, 20>> mutex2;
+    REQUIRE_NOTHROW(mutex2.lock());
+    REQUIRE_NOTHROW(mutex2.unlock());
+
+    REQUIRE_NOTHROW(opencmw::AtomicMutex());
+}

--- a/src/core/test/ThreadAffinity_tests.cpp
+++ b/src/core/test/ThreadAffinity_tests.cpp
@@ -1,6 +1,6 @@
 #include <catch2/catch.hpp>
 #include <Debug.hpp>
-#include <fmt/chrono.h>
+#include <fmt/format.h>
 #include <ThreadAffinity.hpp>
 
 #define REQUIRE_MESSAGE(cond, msg) \

--- a/src/core/test/ThreadPool_tests.cpp
+++ b/src/core/test/ThreadPool_tests.cpp
@@ -1,0 +1,52 @@
+#include <catch2/catch.hpp>
+
+#include <ThreadPool.hpp>
+
+TEST_CASE("Basic ThreadPool tests", "[ThreadPool]") {
+    SECTION("Basic construction/destruction tests") {
+        REQUIRE_NOTHROW(opencmw::BasicThreadPool<opencmw::IO_BOUND>());
+        REQUIRE_NOTHROW(opencmw::BasicThreadPool<opencmw::CPU_BOUND>());
+
+        std::atomic<int>                            enqueueCount{ 0 };
+        std::atomic<int>                            executeCount{ 0 };
+        opencmw::BasicThreadPool<opencmw::IO_BOUND> pool("TestPool", 1, 2);
+        REQUIRE_NOTHROW(pool.sleepDuration() = std::chrono::milliseconds(1));
+        REQUIRE_NOTHROW(pool.keepAliveDuration() = std::chrono::seconds(10));
+        pool.waitUntilInitialised();
+        REQUIRE(pool.isInitialised());
+        std::this_thread::sleep_for(std::chrono::milliseconds(5));
+        REQUIRE(pool.poolName() == "TestPool");
+        REQUIRE(pool.minThreads() == 1);
+        REQUIRE(pool.maxThreads() == 2);
+        REQUIRE(pool.numThreads() == 1);
+        REQUIRE(pool.numTasksRunning() == 0);
+        REQUIRE(pool.numTasksQueued() == 0);
+        REQUIRE(pool.numTasksRecycled() == 0);
+        pool.execute([&enqueueCount] { ++enqueueCount; enqueueCount.notify_all(); });
+        enqueueCount.wait(0);
+        REQUIRE(pool.numThreads() == 1);
+        pool.execute([&executeCount] { ++executeCount; executeCount.notify_all(); });
+        executeCount.wait(0);
+        REQUIRE(pool.numThreads() >= 1);
+        REQUIRE(enqueueCount == 1);
+        REQUIRE(executeCount == 1);
+
+        REQUIRE_NOTHROW(pool.setAffinityMask(pool.getAffinityMask()));
+        REQUIRE_NOTHROW(pool.setThreadSchedulingPolicy(pool.getSchedulingPolicy(), pool.getSchedulingPriority()));
+    }
+
+    SECTION("contention tests") {
+        std::atomic<int>                            counter{ 0 };
+        opencmw::BasicThreadPool<opencmw::IO_BOUND> pool("contention", 1, 4);
+        pool.waitUntilInitialised();
+        REQUIRE(pool.isInitialised());
+        REQUIRE(pool.numThreads() == 1);
+        pool.execute([&counter] { std::this_thread::sleep_for(std::chrono::milliseconds(10)); std::atomic_fetch_add(&counter, 1); counter.notify_all(); });
+        REQUIRE(pool.numThreads() == 1);
+        pool.execute([&counter] { std::this_thread::sleep_for(std::chrono::milliseconds(10)); std::atomic_fetch_add(&counter, 1); counter.notify_all(); });
+        REQUIRE(pool.numThreads() >= 1);
+        counter.wait(0);
+        counter.wait(1);
+        REQUIRE(counter == 2);
+    }
+}


### PR DESCRIPTION
<h2>Basic thread pool that uses a fixed-number or optionally grow/shrink between a [min, max] number of threads.</h2>
The growth policy is controlled by the TaskType template parameter:
<ol type="A">
  <li> <code>TaskType::IO_BOUND</code> if the task is IO bound, i.e. it is likely to block the thread for a long time, or
  <li> <code>TaskType::CPU_BOUND</code> if the task is CPU bound, i.e. it is primarily limited by the CPU and memory bandwidth.
 </ol>
 <br>
 For the IO_BOUND policy, unused threads are kept alive for a pre-defined amount of time to be reused and gracefully
 shut down to the minimum number of threads when unused.
 <br>
 For the CPU_BOUND policy, the threads are equally spread and pinned across the set CPU affinity.
 <br>
 The CPU affinity and OS scheduling policy and priorities are controlled by:
 <ul>
  <li> <code>setAffinityMask(std::vector&lt;bool&gt; threadAffinityMask);</code> </li>
  <li> <code>setThreadSchedulingPolicy(const thread::Policy schedulingPolicy, const int schedulingPriority)</code> </li>
 </ul>

additionally includes:
 * AtomicMutex compatible with std::mutex and std::scoped_lock