### PR TITLE
fixed operator<<(..., Ringbuffer) overloading

### DIFF
--- a/src/disruptor/include/disruptor/RingBuffer.hpp
+++ b/src/disruptor/include/disruptor/RingBuffer.hpp
@@ -283,10 +283,10 @@ struct fmt::formatter<opencmw::disruptor::PollState> {
     }
 };
 
-namespace opencmw {
+namespace opencmw::disruptor {
 
 template<typename T, std::size_t SIZE, disruptor::WaitStrategy WAIT_STRATEGY, template<std::size_t, disruptor::WaitStrategy> typename CLAIM_STRATEGY>
-std::ostream &operator<<(std::ostream &stream, const opencmw::disruptor::RingBuffer<T, SIZE, WAIT_STRATEGY, CLAIM_STRATEGY> &ringBuffer) { return stream << fmt::format("{}", ringBuffer); }
-std::ostream &operator<<(std::ostream &stream, opencmw::disruptor::PollState &pollState) { return stream << fmt::format("{}", pollState); }
+inline std::ostream &operator<<(std::ostream &stream, const opencmw::disruptor::RingBuffer<T, SIZE, WAIT_STRATEGY, CLAIM_STRATEGY> &ringBuffer) { return stream << fmt::format("{}", ringBuffer); }
+inline std::ostream &operator<<(std::ostream &stream, opencmw::disruptor::PollState &pollState) { return stream << fmt::format("{}", pollState); }
 
-} // namespace opencmw
+} // namespace opencmw::disruptor


### PR DESCRIPTION
N.B. apparently gcc 12.1 defined a more strict (??) policy