### PR TITLE
build: Prefer relative `INSTALL_INTERFACE` genex argument

### DIFF
--- a/src/client/CMakeLists.txt
+++ b/src/client/CMakeLists.txt
@@ -1,6 +1,6 @@
 # setup header only library
 add_library(client INTERFACE include/MockServer.hpp include/Client.hpp include/ClientContext.hpp)
-target_include_directories(client INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include> $<INSTALL_INTERFACE:${CMAKE_INSTALL_PREFIX}/include/>)
+target_include_directories(client INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include> $<INSTALL_INTERFACE:include/>)
 target_link_libraries(client INTERFACE utils pthread core disruptor serialiser majordomo)
 set_target_properties(client PROPERTIES PUBLIC_HEADER "include/MockServer.hpp;include/Client.hpp;include/ClientContext.hpp")
 

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -1,6 +1,6 @@
 # setup header only library
 add_library(core INTERFACE)
-target_include_directories(core INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include> $<INSTALL_INTERFACE:${CMAKE_INSTALL_PREFIX}/include/>)
+target_include_directories(core INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include> $<INSTALL_INTERFACE:include/>)
 target_link_libraries(core INTERFACE $<BUILD_INTERFACE:mp-units::mp-units> refl-cpp::refl-cpp utils pthread)
 set_target_properties(core PROPERTIES PUBLIC_HEADER "include/URI.hpp;include/MIME.hpp")
 

--- a/src/disruptor/CMakeLists.txt
+++ b/src/disruptor/CMakeLists.txt
@@ -1,6 +1,6 @@
 # setup header only library
 add_library(disruptor INTERFACE)
-target_include_directories(disruptor INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include> $<INSTALL_INTERFACE:${CMAKE_INSTALL_PREFIX}/include/>)
+target_include_directories(disruptor INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include> $<INSTALL_INTERFACE:include/>)
 target_link_libraries(disruptor INTERFACE $<BUILD_INTERFACE:fmt::fmt-header-only> utils core rxcpp pthread)
 
 install(

--- a/src/majordomo/CMakeLists.txt
+++ b/src/majordomo/CMakeLists.txt
@@ -13,7 +13,7 @@ add_library(majordomo INTERFACE
     include/majordomo/Worker.hpp
     include/majordomo/ZmqPtr.hpp
 )
-target_include_directories(majordomo INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include> $<INSTALL_INTERFACE:${CMAKE_INSTALL_PREFIX}/include/>)
+target_include_directories(majordomo INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include> $<INSTALL_INTERFACE:include/>)
 target_link_libraries(majordomo
         INTERFACE
             utils

--- a/src/serialiser/CMakeLists.txt
+++ b/src/serialiser/CMakeLists.txt
@@ -5,7 +5,7 @@ cmrc_add_resource_library(
 )
 
 add_library(serialiser INTERFACE include/IoSerialiserYAML.hpp)
-target_include_directories(serialiser INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include> $<INSTALL_INTERFACE:${CMAKE_INSTALL_PREFIX}/include/>)
+target_include_directories(serialiser INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include> $<INSTALL_INTERFACE:include/>)
 target_link_libraries(serialiser INTERFACE $<BUILD_INTERFACE: mp-units::mp-units mustache::mustache assets::mustache> refl-cpp::refl-cpp core utils)
 set_target_properties(serialiser PROPERTIES PUBLIC_HEADER "include/fast_float.h;include/IoBuffer.hpp;include/IoSerialiserYaS.hpp;include/IoSerialiserJson.hpp;include/IoSerialiserCmwLight.hpp;include/IoSerialiser.hpp;include/MultiArray.hpp;include/opencmw.hpp")
 

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -1,6 +1,6 @@
 # setup header only library
 add_library(utils INTERFACE)
-target_include_directories(utils INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include> $<INSTALL_INTERFACE:${CMAKE_INSTALL_PREFIX}/include/opencmw/>)
+target_include_directories(utils INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include> $<INSTALL_INTERFACE:include/opencmw/>)
 target_link_libraries(utils INTERFACE $<BUILD_INTERFACE:fmt::fmt-header-only>)
 set_target_properties(utils PROPERTIES PUBLIC_HEADER "include/Debug.hpp;include/Utils.hpp")
 


### PR DESCRIPTION
Absolute paths using `$CMAKE_INSTALL_PREFIX` bake the install prefix value
**at configure time** which
* renders the generated CMake package unrelocatable and
* breaks the modern CMake workflow which supplies the actual install prefix
  value only later, e.g.:

```
cmake -G Ninja -S <source-dir> -B <build-dir>
cmake --build <build-dir>
cmake --install <build-dir> --prefix <absolute-install-dir>
```

See also https://cmake.org/cmake/help/latest/command/target_include_directories.html