### PR TITLE
update mdpmessage wo zeromq dependency

### DIFF
--- a/concepts/majordomo/MajordomoRest_example.cpp
+++ b/concepts/majordomo/MajordomoRest_example.cpp
@@ -121,23 +121,23 @@ struct HelloWorldHandler {
     std::string customFilter = "uninitialised";
 
     void        operator()(RequestContext &rawCtx, const TestContext &requestContext, const Request &in, TestContext &replyContext, Reply &out) {
-               using namespace std::chrono;
-               const auto now        = system_clock::now();
-               const auto sinceEpoch = system_clock::to_time_t(now);
-               out.name              = fmt::format("Hello World! The local time is: {}", std::put_time(std::localtime(&sinceEpoch), "%Y-%m-%d %H:%M:%S"));
-               out.byteArray         = in.name; // doesn't really make sense atm
-               out.byteReturnType    = 42;
+        using namespace std::chrono;
+        const auto now        = system_clock::now();
+        const auto sinceEpoch = system_clock::to_time_t(now);
+        out.name              = fmt::format("Hello World! The local time is: {}", std::put_time(std::localtime(&sinceEpoch), "%Y-%m-%d %H:%M:%S"));
+        out.byteArray         = in.name; // doesn't really make sense atm
+        out.byteReturnType    = 42;
 
-               out.timingCtx         = opencmw::TimingCtx(3, {}, {}, {}, duration_cast<microseconds>(now.time_since_epoch()));
-               if (rawCtx.request.command() == Command::Set) {
-                   customFilter = in.customFilter;
+        out.timingCtx         = opencmw::TimingCtx(3, {}, {}, {}, duration_cast<microseconds>(now.time_since_epoch()));
+        if (rawCtx.request.command() == Command::Set) {
+            customFilter = in.customFilter;
         }
-               out.lsaContext           = customFilter;
+        out.lsaContext           = customFilter;
 
-               replyContext.ctx         = out.timingCtx;
-               replyContext.ctx         = opencmw::TimingCtx(3, {}, {}, {}, duration_cast<microseconds>(now.time_since_epoch()));
-               replyContext.contentType = requestContext.contentType;
-               replyContext.testFilter  = fmt::format("HelloWorld - reply topic = {}", requestContext.testFilter);
+        replyContext.ctx         = out.timingCtx;
+        replyContext.ctx         = opencmw::TimingCtx(3, {}, {}, {}, duration_cast<microseconds>(now.time_since_epoch()));
+        replyContext.contentType = requestContext.contentType;
+        replyContext.testFilter  = fmt::format("HelloWorld - reply topic = {}", requestContext.testFilter);
     }
 };
 
@@ -260,11 +260,11 @@ int main() {
 
     std::jthread                                                                                      helloWorldThread([&helloWorldWorker] {
         helloWorldWorker.run();
-    });
+                                                                                         });
 
     std::jthread                                                                                      imageThread([&imageWorker] {
         imageWorker.run();
-    });
+                                                                                         });
 
     primaryBrokerThread.join();
 

--- a/concepts/majordomo/MajordomoRest_example.cpp
+++ b/concepts/majordomo/MajordomoRest_example.cpp
@@ -121,23 +121,23 @@ struct HelloWorldHandler {
     std::string customFilter = "uninitialised";
 
     void        operator()(RequestContext &rawCtx, const TestContext &requestContext, const Request &in, TestContext &replyContext, Reply &out) {
-        using namespace std::chrono;
-        const auto now        = system_clock::now();
-        const auto sinceEpoch = system_clock::to_time_t(now);
-        out.name              = fmt::format("Hello World! The local time is: {}", std::put_time(std::localtime(&sinceEpoch), "%Y-%m-%d %H:%M:%S"));
-        out.byteArray         = in.name; // doesn't really make sense atm
-        out.byteReturnType    = 42;
+               using namespace std::chrono;
+               const auto now        = system_clock::now();
+               const auto sinceEpoch = system_clock::to_time_t(now);
+               out.name              = fmt::format("Hello World! The local time is: {}", std::put_time(std::localtime(&sinceEpoch), "%Y-%m-%d %H:%M:%S"));
+               out.byteArray         = in.name; // doesn't really make sense atm
+               out.byteReturnType    = 42;
 
-        out.timingCtx         = opencmw::TimingCtx(3, {}, {}, {}, duration_cast<microseconds>(now.time_since_epoch()));
-        if (rawCtx.request.command() == Command::Set) {
-            customFilter = in.customFilter;
+               out.timingCtx         = opencmw::TimingCtx(3, {}, {}, {}, duration_cast<microseconds>(now.time_since_epoch()));
+               if (rawCtx.request.command() == Command::Set) {
+                   customFilter = in.customFilter;
         }
-        out.lsaContext           = customFilter;
+               out.lsaContext           = customFilter;
 
-        replyContext.ctx         = out.timingCtx;
-        replyContext.ctx         = opencmw::TimingCtx(3, {}, {}, {}, duration_cast<microseconds>(now.time_since_epoch()));
-        replyContext.contentType = requestContext.contentType;
-        replyContext.testFilter  = fmt::format("HelloWorld - reply topic = {}", requestContext.testFilter);
+               replyContext.ctx         = out.timingCtx;
+               replyContext.ctx         = opencmw::TimingCtx(3, {}, {}, {}, duration_cast<microseconds>(now.time_since_epoch()));
+               replyContext.contentType = requestContext.contentType;
+               replyContext.testFilter  = fmt::format("HelloWorld - reply topic = {}", requestContext.testFilter);
     }
 };
 
@@ -244,7 +244,7 @@ int main() {
     });
 
     // second broker to test DNS functionalities
-    Broker       secondaryBroker("SecondaryTestBroker", { .dnsAddress = brokerRouterAddress->str });
+    Broker       secondaryBroker("SecondaryTestBroker", { .dnsAddress = brokerRouterAddress->str() });
 
     std::jthread secondaryBrokerThread([&secondaryBroker] {
         secondaryBroker.run();
@@ -260,11 +260,11 @@ int main() {
 
     std::jthread                                                                                      helloWorldThread([&helloWorldWorker] {
         helloWorldWorker.run();
-                                                                                         });
+    });
 
     std::jthread                                                                                      imageThread([&imageWorker] {
         imageWorker.run();
-                                                                                         });
+    });
 
     primaryBrokerThread.join();
 

--- a/src/client/include/Client.hpp
+++ b/src/client/include/Client.hpp
@@ -372,9 +372,9 @@ public:
     }
 
     std::unique_ptr<MDClientBase> createClient(const URI<STRICT> &uri) {
-        if (uri.str.starts_with("mdp")) {
+        if (uri.str().starts_with("mdp")) {
             return std::make_unique<Client>(_zctx, _pollitems, _timeout, _clientId);
-        } else if (uri.str.starts_with("mds")) {
+        } else if (uri.str().starts_with("mds")) {
             return std::make_unique<SubscriptionClient>(_zctx, _pollitems, _timeout, _clientId);
         } else {
             throw std::logic_error("unsupported protocol");
@@ -408,7 +408,7 @@ private:
         cmdType.send(_control_socket_send, ZMQ_DONTWAIT | ZMQ_SNDMORE).assertSuccess();
         majordomo::MessageFrame reqId{ std::to_string(req_id), majordomo::MessageFrame::dynamic_bytes_tag() };
         reqId.send(_control_socket_send, ZMQ_DONTWAIT | ZMQ_SNDMORE).assertSuccess();
-        majordomo::MessageFrame endpoint{ uri.str, majordomo::MessageFrame::dynamic_bytes_tag() };
+        majordomo::MessageFrame endpoint{ uri.str(), majordomo::MessageFrame::dynamic_bytes_tag() };
         endpoint.send(_control_socket_send, ZMQ_DONTWAIT).assertSuccess();
         if (commandType == mdp::Command::Set) {
             majordomo::MessageFrame dataframe{ std::string_view{ reinterpret_cast<const char *>(data.data()), data.size() }, majordomo::MessageFrame::dynamic_bytes_tag() };
@@ -434,7 +434,7 @@ private:
             } else if (cmd.data()[0] == static_cast<char>(mdp::Command::Set)) {
                 majordomo::MessageFrame data;
                 if (!data.receive(_control_socket_recv, ZMQ_DONTWAIT).isValid()) {
-                    throw std::logic_error("missing set data");
+                    throw std::logic_error("missing set str");
                 }
                 client->set(uri, reqId, as_bytes(std::span(data.data().data(), data.data().size())));
             } else if (cmd.data()[0] == static_cast<char>(mdp::Command::Subscribe)) {

--- a/src/client/include/ClientContext.hpp
+++ b/src/client/include/ClientContext.hpp
@@ -10,51 +10,29 @@
 
 #include <disruptor/Disruptor.hpp>
 #include <majordomo/Broker.hpp>
+#include <MdpMessage.hpp>
 #include <URI.hpp>
 
 namespace opencmw::client {
 
-using namespace std::chrono_literals;
-
 using opencmw::uri_check::STRICT;
 using timeUnit = std::chrono::milliseconds;
-
-/**
- * @brief Domain object representation of the Majordomo Protocol (MDP) message
- */
-struct MdpMessage { // return object for received data
-    std::size_t                           id;
-    std::string                           context; // use context type?
-    std::unique_ptr<opencmw::URI<STRICT>> endpoint;
-    IoBuffer                              data;      // request/reply body -- opaque binary, e.g. YaS-, CmwLight-, JSON-, or HTML-based
-    timeUnit                              timestamp_received = 0s;
-};
+using namespace std::chrono_literals;
 
 struct Request {
-    URI<STRICT>                       uri;
-    std::function<void(MdpMessage &)> callback;
-    timeUnit                          timestamp_received = 0s;
+    URI<STRICT>                         uri;
+    std::function<void(mdp::Message &)> callback;
+    timeUnit                            timestamp_received = 0s;
 };
 
 struct Subscription {
-    URI<STRICT>                       uri;
-    std::function<void(MdpMessage &)> callback;
-    timeUnit                          timestamp_received = 0s;
+    URI<STRICT>                         uri;
+    std::function<void(mdp::Message &)> callback;
+    timeUnit                            timestamp_received = 0s;
 };
 
-struct Command {
-    enum class Type {
-        Get,
-        Set,
-        Subscribe,
-        Unsubscribe,
-        Undefined
-    };
-    Type                                    type = Type::Undefined;
-    std::unique_ptr<URI<STRICT>>            uri;
-    std::function<void(const MdpMessage &)> callback; // callback or target ring buffer
-    IoBuffer                                data;     // request/reply body -- opaque binary, e.g. YaS-, CmwLight-, JSON-, or HTML-based
-    timeUnit                                timestamp_received = 0s;
+struct Command : public mdp::Message {
+    std::function<void(const mdp::Message &)> callback; // callback or target ring buffer
 };
 
 static constexpr std::size_t CMD_RB_SIZE = 32;
@@ -95,11 +73,11 @@ public:
     }
 
     // user interface: can be called from any thread and will return non-blocking after submitting the job to the job queue disruptor
-    void get(const URI<STRICT> &endpoint, std::function<void(const MdpMessage &)> &&callback) { queueCommand(Command::Type::Get, endpoint, std::move(callback)); }
-    void set(const URI<STRICT> &endpoint, std::function<void(const MdpMessage &)> &&callback, std::span<uint8_t> &&data) { queueCommand(Command::Type::Set, endpoint, std::move(callback), std::move(data)); }
-    void subscribe(const URI<STRICT> &endpoint) { queueCommand(Command::Type::Subscribe, endpoint); }
-    void subscribe(const URI<STRICT> &endpoint, std::function<void(const MdpMessage &)> &&callback) { queueCommand(Command::Type::Subscribe, endpoint, std::move(callback)); }
-    void unsubscribe(const URI<STRICT> &endpoint) { queueCommand(Command::Type::Unsubscribe, endpoint); }
+    void get(const URI<STRICT> &endpoint, std::function<void(const mdp::Message &)> &&callback) { queueCommand(mdp::Command::Get, endpoint, std::move(callback)); }
+    void set(const URI<STRICT> &endpoint, std::function<void(const mdp::Message &)> &&callback, IoBuffer &&data) { queueCommand(mdp::Command::Set, endpoint, std::move(callback), std::move(data)); }
+    void subscribe(const URI<STRICT> &endpoint) { queueCommand(mdp::Command::Subscribe, endpoint); }
+    void subscribe(const URI<STRICT> &endpoint, std::function<void(const mdp::Message &)> &&callback) { queueCommand(mdp::Command::Subscribe, endpoint, std::move(callback)); }
+    void unsubscribe(const URI<STRICT> &endpoint) { queueCommand(mdp::Command::Unsubscribe, endpoint); }
 
     /*
      * Shutdown all contexts
@@ -116,10 +94,10 @@ private:
     void poll(const std::stop_token &stoken) {
         while (!stoken.stop_requested()) { // switch to event processor instead of busy spinning
             _cmdPoller->poll([this](Command &cmd, std::int64_t /*sequenceID*/, bool /*endOfBatch*/) -> bool {
-                if (cmd.type == Command::Type::Undefined) {
+                if (cmd.command == mdp::Command::Invalid) {
                     return false;
                 }
-                auto &c = getClientCtx(*cmd.uri);
+                auto &c = getClientCtx(*cmd.endpoint);
                 c.request(cmd);
                 return false;
             });
@@ -134,12 +112,12 @@ private:
         }
     };
 
-    void queueCommand(Command::Type cmd, const URI<STRICT> &endpoint, std::function<void(const MdpMessage &)> &&callback = {}, std::span<uint8_t> &&data = {}) {
+    void queueCommand(mdp::Command cmd, const URI<STRICT> &endpoint, std::function<void(const mdp::Message &)> &&callback = {}, IoBuffer &&data = IoBuffer{}) {
         bool published = _commandRingBuffer->tryPublishEvent([&endpoint, &cmd, cb = std::move(callback), d = std::move(data)](Command &&ev, long /*seq*/) mutable {
-            ev.type     = cmd;
+            ev.command  = cmd;
             ev.callback = std::move(cb);
-            ev.uri      = std::make_unique<URI<STRICT>>(endpoint);
-            ev.data     = std::move(IoBuffer(d, true));
+            ev.endpoint = std::make_unique<URI<STRICT>>(endpoint);
+            ev.data     = std::move(d);
         });
         if (!published) {
             fmt::print("failed to publish command\n");

--- a/src/client/include/ClientContext.hpp
+++ b/src/client/include/ClientContext.hpp
@@ -97,7 +97,7 @@ private:
                 if (cmd.command == mdp::Command::Invalid) {
                     return false;
                 }
-                auto &c = getClientCtx(*cmd.endpoint);
+                auto &c = getClientCtx(cmd.endpoint);
                 c.request(cmd);
                 return false;
             });
@@ -116,7 +116,7 @@ private:
         bool published = _commandRingBuffer->tryPublishEvent([&endpoint, &cmd, cb = std::move(callback), d = std::move(data)](Command &&ev, long /*seq*/) mutable {
             ev.command  = cmd;
             ev.callback = std::move(cb);
-            ev.endpoint = std::make_unique<URI<STRICT>>(endpoint);
+            ev.endpoint = FWD(endpoint);
             ev.data     = std::move(d);
         });
         if (!published) {

--- a/src/client/test/ClientPublisher_tests.cpp
+++ b/src/client/test/ClientPublisher_tests.cpp
@@ -39,11 +39,11 @@ TEST_CASE("Basic get/set test", "[ClientContext]") {
     server.processRequest([&endpoint](auto &&req, auto &reply) {
         REQUIRE(req.command() == Command::Get);
         reply.setBody(std::to_string(100), MessageFrame::dynamic_bytes_tag{});
-        reply.setTopic(URI<STRICT>::factory(endpoint).addQueryParameter("ctx", "test_ctx").build().str, MessageFrame::dynamic_bytes_tag{});
+        reply.setTopic(URI<STRICT>::factory(endpoint).addQueryParameter("ctx", "test_ctx").build().str(), MessageFrame::dynamic_bytes_tag{});
     });
     std::this_thread::sleep_for(20ms); // hacky: this is needed because the requests are only identified using their uri, so we cannot have multiple requests with identical uris
     fmt::print("issuing set request\n");
-    auto testData = std::vector<std::byte>{ std::byte{ 'a' }, std::byte{ 'b' }, std::byte{ 'c' } };
+    auto              testData = std::vector<std::byte>{ std::byte{ 'a' }, std::byte{ 'b' }, std::byte{ 'c' } };
     opencmw::IoBuffer dataSetRequest;
     dataSetRequest.put('a');
     dataSetRequest.put('b');
@@ -53,13 +53,14 @@ TEST_CASE("Basic get/set test", "[ClientContext]") {
                 REQUIRE(message.data.size() == 0); // == "100");
                 REQUIRE(message.context == "test_ctx");
                 received++;
-            }, std::move(dataSetRequest));
+            },
+            std::move(dataSetRequest));
     std::this_thread::sleep_for(20ms); // allow the request to reach the server
     server.processRequest([&endpoint](auto &&req, auto &reply) {
         REQUIRE(req.command() == Command::Set);
         REQUIRE(req.body() == "abc");
         reply.setBody(std::string(), MessageFrame::dynamic_bytes_tag{});
-        reply.setTopic(URI<STRICT>::factory(endpoint).addQueryParameter("ctx", "test_ctx").build().str, MessageFrame::dynamic_bytes_tag{});
+        reply.setTopic(URI<STRICT>::factory(endpoint).addQueryParameter("ctx", "test_ctx").build().str(), MessageFrame::dynamic_bytes_tag{});
     });
     std::this_thread::sleep_for(10ms); // allow the reply to reach the client
     REQUIRE(received == 2);
@@ -88,7 +89,7 @@ TEST_CASE("Basic subscription test", "[ClientContext]") {
     std::this_thread::sleep_for(10ms); // allow for the subscription request to be processed
     // send notifications
     for (int i = 0; i < 100; i++) {
-        server.notify("a.service", endpoint.str, "bar-baz");
+        server.notify("a.service", endpoint.str(), "bar-baz");
         fmt::print("^");
     }
     std::this_thread::sleep_for(10ms); // allow for all the notifications to reach the client
@@ -98,7 +99,7 @@ TEST_CASE("Basic subscription test", "[ClientContext]") {
     std::this_thread::sleep_for(10ms); // allow for the unsubscription request to be processed
     // send notifications
     for (int i = 0; i < 100; i++) {
-        server.notify("a.service", endpoint.str, "bar-baz");
+        server.notify("a.service", endpoint.str(), "bar-baz");
         fmt::print("^");
     }
     std::this_thread::sleep_for(10ms); // allow for all the notifications to reach the client

--- a/src/client/test/ClientPublisher_tests.cpp
+++ b/src/client/test/ClientPublisher_tests.cpp
@@ -1,6 +1,7 @@
 #include <catch2/catch.hpp>
-#define ENABLE_RESULT_CHECKS 1
+
 #include <Client.hpp>
+#include <IoBuffer.hpp>
 #include <MockServer.hpp>
 
 namespace opencmw_client_publisher_test {
@@ -29,7 +30,7 @@ TEST_CASE("Basic get/set test", "[ClientContext]") {
     auto endpoint = URI<STRICT>::factory(URI<STRICT>(server.address())).scheme("mdp").path("/a.service").addQueryParameter("C", "2").build();
     fmt::print("issuing get request\n");
     std::atomic<int> received{ 0 };
-    clientContext.get(endpoint, [&received](const opencmw::client::MdpMessage &message) {
+    clientContext.get(endpoint, [&received](const opencmw::mdp::Message &message) {
         REQUIRE(message.data.size() == 3); // == "100");
         REQUIRE(message.context == "test_ctx");
         received++;
@@ -42,13 +43,17 @@ TEST_CASE("Basic get/set test", "[ClientContext]") {
     });
     std::this_thread::sleep_for(20ms); // hacky: this is needed because the requests are only identified using their uri, so we cannot have multiple requests with identical uris
     fmt::print("issuing set request\n");
+    auto testData = std::vector<std::byte>{ std::byte{ 'a' }, std::byte{ 'b' }, std::byte{ 'c' } };
+    opencmw::IoBuffer dataSetRequest;
+    dataSetRequest.put('a');
+    dataSetRequest.put('b');
+    dataSetRequest.put('c');
     clientContext.set(
-            endpoint, [&received](const opencmw::client::MdpMessage &message) {
-                REQUIRE(message.data.empty()); // == "100");
+            endpoint, [&received](const opencmw::mdp::Message &message) {
+                REQUIRE(message.data.size() == 0); // == "100");
                 REQUIRE(message.context == "test_ctx");
                 received++;
-            },
-            std::vector<std::byte>{ std::byte{ 'a' }, std::byte{ 'b' }, std::byte{ 'c' } });
+            }, std::move(dataSetRequest));
     std::this_thread::sleep_for(20ms); // allow the request to reach the server
     server.processRequest([&endpoint](auto &&req, auto &reply) {
         REQUIRE(req.command() == Command::Set);
@@ -71,7 +76,7 @@ TEST_CASE("Basic subscription test", "[ClientContext]") {
     auto endpoint = URI<STRICT>::factory(URI<STRICT>(server.addressSub())).scheme("mds").path("/a.service").addQueryParameter("C", "2").build();
     fmt::print("subscribing\n");
     std::atomic<int> received{ 0 };
-    clientContext.subscribe(endpoint, [&received](const opencmw::client::MdpMessage &update) {
+    clientContext.subscribe(endpoint, [&received](const opencmw::mdp::Message &update) {
         if (update.data.size() == 7) {
             received++;
             fmt::print("v");

--- a/src/client/test/ClientPublisher_tests.cpp
+++ b/src/client/test/ClientPublisher_tests.cpp
@@ -29,7 +29,7 @@ TEST_CASE("Basic get/set test", "[ClientContext]") {
     auto endpoint = URI<STRICT>::factory(URI<STRICT>(server.address())).scheme("mdp").path("/a.service").addQueryParameter("C", "2").build();
     fmt::print("issuing get request\n");
     std::atomic<int> received{ 0 };
-    clientContext.get(endpoint, [&received](const opencmw::client::RawMessage &message) {
+    clientContext.get(endpoint, [&received](const opencmw::client::MdpMessage &message) {
         REQUIRE(message.data.size() == 3); // == "100");
         REQUIRE(message.context == "test_ctx");
         received++;
@@ -43,7 +43,7 @@ TEST_CASE("Basic get/set test", "[ClientContext]") {
     std::this_thread::sleep_for(20ms); // hacky: this is needed because the requests are only identified using their uri, so we cannot have multiple requests with identical uris
     fmt::print("issuing set request\n");
     clientContext.set(
-            endpoint, [&received](const opencmw::client::RawMessage &message) {
+            endpoint, [&received](const opencmw::client::MdpMessage &message) {
                 REQUIRE(message.data.empty()); // == "100");
                 REQUIRE(message.context == "test_ctx");
                 received++;
@@ -71,7 +71,7 @@ TEST_CASE("Basic subscription test", "[ClientContext]") {
     auto endpoint = URI<STRICT>::factory(URI<STRICT>(server.addressSub())).scheme("mds").path("/a.service").addQueryParameter("C", "2").build();
     fmt::print("subscribing\n");
     std::atomic<int> received{ 0 };
-    clientContext.subscribe(endpoint, [&received](const opencmw::client::RawMessage &update) {
+    clientContext.subscribe(endpoint, [&received](const opencmw::client::MdpMessage &update) {
         if (update.data.size() == 7) {
             received++;
             fmt::print("v");

--- a/src/client/test/CmwClient_tests.cpp
+++ b/src/client/test/CmwClient_tests.cpp
@@ -38,9 +38,9 @@ TEST_CASE("Basic Client Get/Set Test", "[Client]") {
             reply.setBody("42", MessageFrame::dynamic_bytes_tag{});
             reply.setTopic(URI<uri_check::STRICT>::factory(uri).addQueryParameter("ctx", "test_ctx1").build().str, MessageFrame::dynamic_bytes_tag{});
         });
-        opencmw::client::RawMessage result;
+        opencmw::client::MdpMessage result;
         REQUIRE(client.receive(result));
-        REQUIRE(result.data == std::vector<std::byte>{ std::byte{ '4' }, std::byte{ '2' } });
+        REQUIRE(result.data.asString() == "42");
         REQUIRE(result.context == "test_ctx1");
     }
 
@@ -56,9 +56,9 @@ TEST_CASE("Basic Client Get/Set Test", "[Client]") {
             reply.setTopic(URI<uri_check::STRICT>::factory(uri).addQueryParameter("ctx", "test_ctx2").build().str, MessageFrame::dynamic_bytes_tag{});
         });
 
-        opencmw::client::RawMessage result;
+        opencmw::client::MdpMessage result;
         REQUIRE(client.receive(result));
-        REQUIRE(result.data.empty());
+        REQUIRE(result.data.size() == 0);
         REQUIRE(result.context == "test_ctx2");
     }
 }
@@ -83,15 +83,15 @@ TEST_CASE("Basic Client Subscription Test", "[Client]") {
     server.notify("a.service", URI<uri_check::STRICT>::factory(endpoint).addQueryParameter("ctx", "test_ctx2").build().str, "102");
 
     {
-        opencmw::client::RawMessage result;
+        opencmw::client::MdpMessage result;
         REQUIRE(subscriptionClient.receive(result));
-        REQUIRE(result.data == std::vector<std::byte>{ std::byte{ '1' }, std::byte{ '0' }, std::byte{ '1' } });
+        REQUIRE(result.data.asString() == "101");
         REQUIRE(result.context == "test_ctx1");
     }
     {
-        opencmw::client::RawMessage result;
+        opencmw::client::MdpMessage result;
         REQUIRE(subscriptionClient.receive(result));
-        REQUIRE(result.data == std::vector<std::byte>{ std::byte{ '1' }, std::byte{ '0' }, std::byte{ '2' } });
+        REQUIRE(result.data.asString() == "102");
         REQUIRE(result.context == "test_ctx2");
     }
     {

--- a/src/client/test/CmwClient_tests.cpp
+++ b/src/client/test/CmwClient_tests.cpp
@@ -36,7 +36,7 @@ TEST_CASE("Basic Client Get/Set Test", "[Client]") {
             REQUIRE(req.body() == "");
             REQUIRE(req.clientRequestId() == "1");
             reply.setBody("42", MessageFrame::dynamic_bytes_tag{});
-            reply.setTopic(URI<uri_check::STRICT>::factory(uri).addQueryParameter("ctx", "test_ctx1").build().str, MessageFrame::dynamic_bytes_tag{});
+            reply.setTopic(URI<uri_check::STRICT>::factory(uri).addQueryParameter("ctx", "test_ctx1").build().str(), MessageFrame::dynamic_bytes_tag{});
         });
         opencmw::mdp::Message result;
         REQUIRE(client.receive(result));
@@ -53,7 +53,7 @@ TEST_CASE("Basic Client Get/Set Test", "[Client]") {
             REQUIRE(req.body() == "100");
             REQUIRE(req.clientRequestId() == "2");
             reply.setBody("", MessageFrame::dynamic_bytes_tag{});
-            reply.setTopic(URI<uri_check::STRICT>::factory(uri).addQueryParameter("ctx", "test_ctx2").build().str, MessageFrame::dynamic_bytes_tag{});
+            reply.setTopic(URI<uri_check::STRICT>::factory(uri).addQueryParameter("ctx", "test_ctx2").build().str(), MessageFrame::dynamic_bytes_tag{});
         });
 
         opencmw::mdp::Message result;
@@ -79,8 +79,8 @@ TEST_CASE("Basic Client Subscription Test", "[Client]") {
     subscriptionClient.subscribe(endpoint, reqId);
     std::this_thread::sleep_for(50ms); // allow for subscription to be established
 
-    server.notify("a.service", URI<uri_check::STRICT>::factory(endpoint).addQueryParameter("ctx", "test_ctx1").build().str, "101");
-    server.notify("a.service", URI<uri_check::STRICT>::factory(endpoint).addQueryParameter("ctx", "test_ctx2").build().str, "102");
+    server.notify("a.service", URI<uri_check::STRICT>::factory(endpoint).addQueryParameter("ctx", "test_ctx1").build().str(), "101");
+    server.notify("a.service", URI<uri_check::STRICT>::factory(endpoint).addQueryParameter("ctx", "test_ctx2").build().str(), "102");
 
     opencmw::mdp::Message resultOfNotify1;
     REQUIRE(subscriptionClient.receive(resultOfNotify1));

--- a/src/core/include/MdpMessage.hpp
+++ b/src/core/include/MdpMessage.hpp
@@ -1,0 +1,52 @@
+#ifndef OPENCMW_CPP_MDPMESSAGE_HPP
+#define OPENCMW_CPP_MDPMESSAGE_HPP
+
+#include <IoBuffer.hpp>
+#include <opencmw.hpp>
+#include <URI.hpp>
+
+namespace opencmw::mdp {
+
+enum class MessageFormat {
+    WithSourceId,   ///< 9-frame format, contains the source ID as frame 0, used with ROUTER sockets (broker)
+    WithoutSourceId ///< 8-frame format, does not contain the source ID frame
+};
+
+enum class Command : unsigned char {
+    Invalid     = 0x00,
+    Get         = 0x01,
+    Set         = 0x02,
+    Partial     = 0x03,
+    Final       = 0x04,
+    Ready       = 0x05, ///< optional for client
+    Disconnect  = 0x06, ///< optional for client
+    Subscribe   = 0x07, ///< client-only
+    Unsubscribe = 0x08, ///< client-only
+    Notify      = 0x09, ///< worker-only
+    Heartbeat   = 0x0a  ///< optional for client
+};
+
+/**
+ * @brief Domain object representation of the Majordomo Protocol (MDP) message
+ */
+struct Message {
+    using timeUnit = std::chrono::milliseconds;
+    using URI = opencmw::URI<opencmw::uri_check::STRICT>;
+
+    std::size_t          id;
+    timeUnit             arrivalTime = std::chrono::milliseconds(0); // UTC time when the message was sent/received by the client
+    timeUnit             timeout     = std::chrono::seconds(10);     // default request/reply timeout
+    std::string          context;                                    // use context type?
+    std::string          protocolName;                               // unique protocol name including version (e.g. 'MDPC03' or 'MDPW03')
+    Command              command = Command::Invalid;                 // command type (GET, SET, SUBSCRIBE, UNSUBSCRIBE, PARTIAL, FINAL, NOTIFY, READY, DISCONNECT, HEARTBEAT)
+    URI                  serviceName{ "/" };                         // service endpoint name (normally the URI path only
+    IoBuffer             clientRequestID;                            // stateful: worker mirrors clientRequestID; stateless: worker generates unique increasing IDs (to detect packet loss)
+    std::unique_ptr<URI> endpoint;                                   // URI containing at least <path> and optionally <query> parameters
+    IoBuffer             data;                                       // request/reply body -- opaque binary, e.g. YaS-, CmwLight-, JSON-, or HTML-based
+    std::string          error;                                      // UTF-8 strings containing  error code and/or stack-trace (e.g. "404 Not Found")
+    IoBuffer             rbac;                                       // optional RBAC meta-info -- may contain token, role, signed message hash (implementation dependent)
+};
+
+} // namespace opencmw::mdp
+
+#endif // OPENCMW_CPP_MDPMESSAGE_HPP

--- a/src/core/include/MdpMessage.hpp
+++ b/src/core/include/MdpMessage.hpp
@@ -31,20 +31,20 @@ enum class Command : unsigned char {
  */
 struct Message {
     using timeUnit = std::chrono::milliseconds;
-    using URI = opencmw::URI<opencmw::uri_check::STRICT>;
+    using URI      = opencmw::URI<opencmw::uri_check::STRICT>;
 
-    std::size_t          id;
-    timeUnit             arrivalTime = std::chrono::milliseconds(0); // UTC time when the message was sent/received by the client
-    timeUnit             timeout     = std::chrono::seconds(10);     // default request/reply timeout
-    std::string          context;                                    // use context type?
-    std::string          protocolName;                               // unique protocol name including version (e.g. 'MDPC03' or 'MDPW03')
-    Command              command = Command::Invalid;                 // command type (GET, SET, SUBSCRIBE, UNSUBSCRIBE, PARTIAL, FINAL, NOTIFY, READY, DISCONNECT, HEARTBEAT)
-    URI                  serviceName{ "/" };                         // service endpoint name (normally the URI path only
-    IoBuffer             clientRequestID;                            // stateful: worker mirrors clientRequestID; stateless: worker generates unique increasing IDs (to detect packet loss)
-    std::unique_ptr<URI> endpoint;                                   // URI containing at least <path> and optionally <query> parameters
-    IoBuffer             data;                                       // request/reply body -- opaque binary, e.g. YaS-, CmwLight-, JSON-, or HTML-based
-    std::string          error;                                      // UTF-8 strings containing  error code and/or stack-trace (e.g. "404 Not Found")
-    IoBuffer             rbac;                                       // optional RBAC meta-info -- may contain token, role, signed message hash (implementation dependent)
+    std::size_t id;
+    timeUnit    arrivalTime = std::chrono::milliseconds(0); // UTC time when the message was sent/received by the client
+    timeUnit    timeout     = std::chrono::seconds(10);     // default request/reply timeout
+    std::string context;                                    // use context type?
+    std::string protocolName;                               // unique protocol name including version (e.g. 'MDPC03' or 'MDPW03')
+    Command     command = Command::Invalid;                 // command type (GET, SET, SUBSCRIBE, UNSUBSCRIBE, PARTIAL, FINAL, NOTIFY, READY, DISCONNECT, HEARTBEAT)
+    URI         serviceName{ "/" };                         // service endpoint name (normally the URI path only
+    IoBuffer    clientRequestID;                            // stateful: worker mirrors clientRequestID; stateless: worker generates unique increasing IDs (to detect packet loss)
+    URI         endpoint{ "/" };                            // URI containing at least <path> and optionally <query> parameters
+    IoBuffer    data;                                       // request/reply body -- opaque binary, e.g. YaS-, CmwLight-, JSON-, or HTML-based
+    std::string error;                                      // UTF-8 strings containing  error code and/or stack-trace (e.g. "404 Not Found")
+    IoBuffer    rbac;                                       // optional RBAC meta-info -- may contain token, role, signed message hash (implementation dependent)
 };
 
 } // namespace opencmw::mdp

--- a/src/core/include/URI.hpp
+++ b/src/core/include/URI.hpp
@@ -61,7 +61,7 @@ public:
     noexcept { *this = other; }
     URI(const URI &&other)
     noexcept { *this = std::move(other); }
-    ~URI() = default;
+    ~URI()       = default;
 
     URI &operator=(const URI &other) noexcept {
         if (this == &other) {
@@ -383,30 +383,30 @@ private:
     // returns tif only RFC 3986 section 2.3 Unreserved Characters
     static constexpr inline bool isUnreserved(const char c) noexcept { return std::isalnum(c) || c == '-' || c == '_' || c == '.' || c == '~'; }
     constexpr inline void        parseAuthority() const {
-               if (_parsedAuthority || _authority.empty()) {
-                   _parsedAuthority = true;
-                   return;
+        if (_parsedAuthority || _authority.empty()) {
+            _parsedAuthority = true;
+            return;
         }
-               size_t userSplit = std::min(_authority.find_first_of('@'), _authority.length());
-               if (userSplit < _authority.length()) {
-                   // user isUnreserved defined via '[user]:[pwd]@'
+        size_t userSplit = std::min(_authority.find_first_of('@'), _authority.length());
+        if (userSplit < _authority.length()) {
+            // user isUnreserved defined via '[user]:[pwd]@'
             const size_t pwdSplit = std::min(_authority.find_first_of(':'), userSplit);
             _userName             = _authority.substr(0, pwdSplit);
             if (pwdSplit < userSplit) {
-                       _pwd = _authority.substr(pwdSplit + 1, userSplit - pwdSplit - 1);
+                _pwd = _authority.substr(pwdSplit + 1, userSplit - pwdSplit - 1);
             }
             userSplit++;
         } else {
-                   userSplit = 0;
+            userSplit = 0;
         }
-               size_t portSplit = std::min(_authority.find_first_of(':', userSplit), _authority.length());
-               if (portSplit != std::string_view::npos && portSplit < _authority.length()) {
-                   // port defined
+        size_t portSplit = std::min(_authority.find_first_of(':', userSplit), _authority.length());
+        if (portSplit != std::string_view::npos && portSplit < _authority.length()) {
+            // port defined
             _hostName = _authority.substr(userSplit, portSplit - userSplit);
             portSplit++;
             _port = _authority.substr(portSplit, _authority.length() - portSplit);
         } else {
-                   _hostName = _authority.substr(userSplit, _authority.length() - userSplit);
+            _hostName = _authority.substr(userSplit, _authority.length() - userSplit);
         }
     }
 };

--- a/src/core/include/URI.hpp
+++ b/src/core/include/URI.hpp
@@ -34,11 +34,10 @@ enum uri_check {
 // regex test: regexr.com/69hv8
 template<uri_check check = STRICT>
 class URI {
-    using string      = std::string;
     using string_view = std::string_view;
 
 public:
-    const string str;
+    std::string str;
 
 private:
     // need to keep a local, owning, and immutable copy of the source template
@@ -55,50 +54,257 @@ private:
     string_view         _fragment;
 
     // computed on-demand
-    mutable std::unordered_map<string, std::optional<string>> _queryMap;
-    // simple optional un-wrapper
-    inline const std::optional<string> returnOpt(const string_view &src) const noexcept {
-        if (!src.empty()) {
-            assert(src.data() >= str.data() && src.data() < str.data() + str.size());
-        }
-        return src.empty() ? std::nullopt : std::optional<string>(src);
-    };
-
-protected:
-    // returns tif only RFC 3986 section 2.3 Unreserved Characters
-    static constexpr inline bool isUnreserved(const char c) noexcept { return std::isalnum(c) || c == '-' || c == '_' || c == '.' || c == '~'; }
-    constexpr inline void        parseAuthority() const {
-        if (_parsedAuthority || _authority.empty()) {
-            _parsedAuthority = true;
-            return;
-        }
-        size_t userSplit = std::min(_authority.find_first_of('@'), _authority.length());
-        if (userSplit < _authority.length()) {
-            // user isUnreserved defined via '[user]:[pwd]@'
-            const size_t pwdSplit = std::min(_authority.find_first_of(':'), userSplit);
-            _userName             = _authority.substr(0, pwdSplit);
-            if (pwdSplit < userSplit) {
-                _pwd = _authority.substr(pwdSplit + 1, userSplit - pwdSplit - 1);
-            }
-            userSplit++;
-        } else {
-            userSplit = 0;
-        }
-        size_t portSplit = std::min(_authority.find_first_of(':', userSplit), _authority.length());
-        if (portSplit != string_view::npos && portSplit < _authority.length()) {
-            // port defined
-            _hostName = _authority.substr(userSplit, portSplit - userSplit);
-            portSplit++;
-            _port = _authority.substr(portSplit, _authority.length() - portSplit);
-        } else {
-            _hostName = _authority.substr(userSplit, _authority.length() - userSplit);
-        }
-    }
+    mutable std::unordered_map<std::string, std::optional<std::string>> _queryMap;
 
 public:
     URI() = delete;
-    explicit URI(std::string src)
-        : str(std::move(src)) {
+    explicit URI(const std::string &src)
+        : str(src) { parseURI(); }
+    explicit URI(std::string &&src)
+        : str(std::move(src)) { parseURI(); }
+    URI(const URI &other)
+    noexcept { *this = other; }
+    URI(const URI &&other)
+    noexcept { *this = std::move(other); }
+
+    URI &operator=(const URI &other) noexcept {
+        if (this == &other) {
+            return *this;
+        }
+        str               = other.str;
+        auto adjustedView = [this, &other](std::string_view otherView) {
+            return std::string_view(str.data() + std::distance(other.str.data(), otherView.data()), otherView.size());
+        };
+        _scheme    = adjustedView(other._scheme);
+        _authority = adjustedView(other._authority);
+        _path      = adjustedView(other._path);
+        _query     = adjustedView(other._query);
+        _fragment  = adjustedView(other._fragment);
+        if (_query.empty()) {
+            _queryMap.clear();
+        } else {
+            _queryMap = other._queryMap;
+        }
+
+        _parsedAuthority = other._parsedAuthority;
+        if (!_parsedAuthority) {
+            return *this;
+        }
+        _userName = adjustedView(other._userName);
+        _pwd      = adjustedView(other._pwd);
+        _hostName = adjustedView(other._hostName);
+        _port     = adjustedView(other._port);
+        return *this;
+    }
+
+    URI &operator=(URI &&other) noexcept {
+        if (this == &other) {
+            return *this;
+        }
+        str        = std::move(other.str);
+        _scheme    = std::move(other._scheme);
+        _authority = std::move(other._authority);
+        _path      = std::move(other._path);
+        _query     = std::move(other._query);
+        _fragment  = std::move(other._fragment);
+        std::swap(_queryMap, other._queryMap);
+
+        std::swap(_parsedAuthority, other._parsedAuthority);
+        _userName = std::move(other._userName);
+        _pwd      = std::move(other._pwd);
+        _hostName = std::move(other._hostName);
+        _port     = std::move(other._port);
+        return *this;
+    }
+
+    bool               empty() const { return str.empty(); }
+
+    static std::string encode(const std::string_view &source) noexcept {
+        std::ostringstream encoded;
+        encoded.fill('0');
+        encoded << std::hex;
+
+        for (auto c : source) {
+            if (isUnreserved(c)) {
+                // keep RFC 3986 section 2.3 Unreserved Characters i.e. [a-zA-Z0-9-_-~]
+                encoded << c;
+            } else {
+                // percent-encode RFC 3986 section 2.2 Reserved Characters i.e. [!#$%&'()*+,/:;=?@[]]
+                encoded << std::uppercase;
+                encoded << '%' << std::setw(2) << int(static_cast<uint8_t>(c));
+                encoded << std::nouppercase;
+            }
+        }
+
+        return encoded.str();
+    }
+
+    static std::string decode(const std::string_view &s) {
+        std::ostringstream decoded;
+        for (size_t i = 0; i < s.size(); ++i) {
+            char c = s[i];
+            if (c == '%') {
+                // percent-encode RFC 3986 section 2.2 Reserved Characters i.e. [!#$%&'()*+,/:;=?@[]]
+                if constexpr (check == STRICT) {
+                    if (!std::isxdigit(s[i + 1])) {
+                        throw URISyntaxException(fmt::format("additional erroneous character '{}' found after '%' at {} of '{}'", s[i + 1], i + 1, s));
+                    }
+                }
+                int                d;
+                std::istringstream iss(std::string(s.substr(i + 1, 2))); // TODO find smarter conversion
+                iss >> std::hex >> d;
+                decoded << static_cast<uint8_t>(d);
+                i += 2;
+            } else {
+                decoded << c;
+            }
+        }
+        return decoded.str();
+    }
+
+    // clang-format off
+    inline const std::optional<std::string> scheme() const noexcept { return returnOpt(_scheme); }
+    inline const std::optional<std::string> authority() const noexcept { return returnOpt(_authority); }
+    inline const std::optional<std::string> user() const noexcept { parseAuthority(); return returnOpt(_userName); }
+    inline const std::optional<std::string> password() const noexcept { parseAuthority(); return returnOpt(_pwd); }
+    inline const std::optional<std::string> hostName() const noexcept { parseAuthority(); return returnOpt(_hostName); }
+    inline const std::optional<uint16_t> port() const noexcept { parseAuthority(); return _port.empty() ? std::nullopt : std::optional(std::stoi(std::string{ _port.begin(), _port.end() }));}
+    inline const std::optional<std::string> path() const noexcept { return returnOpt(_path); }
+    inline const std::optional<std::string> queryParam() const noexcept { return returnOpt(_query); }
+    inline const std::optional<std::string> fragment() const noexcept { return returnOpt(_fragment); }
+    // clang-format om
+
+    // decompose map
+    inline const std::unordered_map<std::string, std::optional<std::string>> &queryParamMap() const {
+        if (_query.empty() || !_queryMap.empty()) { // empty query parameter or already parsed
+            return _queryMap;
+        }
+        if constexpr (check == STRICT) {
+            if (!std::all_of(_query.begin(), _query.end(), [](char c) { return isUnreserved(c) || c == '&' || c == ';' || c == '=' || c == '%' || c == ':' || c == '/'; })) {
+                throw URISyntaxException(fmt::format("URI query contains illegal characters: {}", _query));
+            }
+        }
+        size_t readPos = 0;
+        while (readPos < _query.length()) {
+            auto keyEnd = _query.find_first_of("=;&\0", readPos);
+            if (keyEnd != string_view::npos && keyEnd < _query.length()) {
+                auto key = decode(_query.substr(readPos, keyEnd - readPos));
+                if (_query[keyEnd] != '=') {
+                    _queryMap[key] = std::nullopt;
+                    readPos        = keyEnd + 1; //+1 for separator character
+                    continue;
+                }
+                readPos = keyEnd + 1; // skip equal after '='
+                // equal sign present
+                if (readPos >= _query.length()) {
+                    // reached parameter string end
+                    _queryMap[key] = std::nullopt;
+                    break;
+                }
+                const auto valueEnd = _query.find_first_of(";&\0", readPos);
+                if (valueEnd != string_view::npos && valueEnd < _query.length()) {
+                    _queryMap[key] = std::optional(decode(_query.substr(readPos, valueEnd - readPos)));
+                    readPos        = valueEnd + 1;
+                    continue;
+                }
+                const auto value = decode(_query.substr(readPos, _query.length() - readPos));
+                _queryMap[key] = value.empty() ? std::nullopt : std::optional(value);
+                break;
+            } else {
+                auto key       = std::string(_query.substr(readPos, _query.length() - readPos));
+                _queryMap[key] = std::nullopt;
+                break;
+            }
+        }
+
+        return _queryMap;
+    };
+
+    // comparison operators
+    auto operator<=>(const URI &other) const noexcept { return str <=> other.str; }
+    bool operator==(const URI &other) const noexcept  { return str == other.str; }
+
+    class UriFactory {
+        std::string             _authority;
+        std::string             _scheme;
+        std::string             _userName;
+        std::string             _pwd;
+        std::string             _host;
+        std::optional<uint16_t> _port;
+        std::string             _path;
+        std::string             _query;
+        std::string             _fragment;
+        // local map to overwrite _query parameter if set
+        std::unordered_map<std::string, std::optional<std::string>> _queryMap;
+
+    public:
+        UriFactory() = default;
+        // clang-format off
+        explicit UriFactory(const URI &uri) {
+            if (!uri._scheme.empty())    { _scheme = uri._scheme; }
+            if (!uri._authority.empty()) { _authority = uri._authority; }
+            if (!uri._userName.empty())  { _userName = uri._userName; }
+            if (!uri._pwd.empty())       { _pwd = uri._pwd; }
+            if (!uri._hostName.empty())  { _host = uri._hostName; }
+            if (!uri._port.empty())      { _port = std::stoi(std::string(uri._port)); }
+            if (!uri._path.empty())      { _path = uri._path; }
+            if (!uri._query.empty())     { _query = uri._query; }
+            if (!uri._fragment.empty())  { _fragment = uri._fragment; }
+        }
+        inline UriFactory&& scheme(const std::string_view &scheme)        && noexcept { _scheme = scheme; return std::move(*this); }
+        inline UriFactory&& authority(const std::string_view &authority)  && noexcept { _authority = { authority.begin(), authority.end() }; return std::move(*this); }
+        inline UriFactory&& user(const std::string_view &userName)        && noexcept { _userName = { userName.begin(), userName.end() }; return std::move(*this); }
+        inline UriFactory&& password(const std::string_view &pwd)         && noexcept { _pwd = { pwd.begin(), pwd.end() }; return std::move(*this); }
+        inline UriFactory&& hostName(const std::string_view &hostName)    && noexcept { _host = { hostName.begin(), hostName.end() }; return std::move(*this); }
+        inline UriFactory&& port(const uint16_t port)                     && noexcept { _port = std::optional<uint16_t>(port); return std::move(*this); }
+        inline UriFactory&& path(const std::string_view &path)            && noexcept { _path = { path.begin(), path.end() }; return std::move(*this); }
+        inline UriFactory&& queryParam(const std::string_view &query)     && noexcept { _query = { query.begin(), query.end() }; return std::move(*this); }
+        inline UriFactory&& fragment(const std::string_view &fragment)    && noexcept { _fragment = { fragment.begin(), fragment.end() }; return std::move(*this); }
+        inline UriFactory&& addQueryParameter(const std::string &key)     && noexcept { _queryMap[key] = std::nullopt; return std::move(*this); }
+        inline UriFactory&& addQueryParameter(const std::string &key, const std::string &value) && noexcept { _queryMap[key] = std::optional(value); return std::move(*this); }
+        inline UriFactory&& setQuery(std::unordered_map<std::string, std::optional<std::string>> queryMap) && noexcept { _query.clear(); _queryMap = std::move(queryMap); return std::move(*this); }
+        // clang-format on
+
+        std::string toString() {
+            using namespace fmt::literals;
+            if (_authority.empty()) {
+                _authority = fmt::format("{user}{opt_colon1}{pwd}{at}{host}{opt_colon2}{port}",                //
+                        "user"_a = _userName, "opt_colon1"_a = (_pwd.empty() || _userName.empty()) ? "" : ":", /* user:pwd colon separator */
+                        "pwd"_a = _userName.empty() ? "" : _pwd, "at"_a = _userName.empty() ? "" : "@",        // 'user:pwd@' separator
+                        "host"_a = _host, "opt_colon2"_a = _port ? ":" : "", "port"_a = _port ? std::to_string(_port.value()) : "");
+            }
+
+            for (const auto &[key, value] : _queryMap) {
+                _query += fmt::format("{opt_ampersand}{key}{opt_equal}{value}",               // N.B. 'key=value' percent-encoding according to RFC 3986
+                        "opt_ampersand"_a = _query.empty() ? "" : "&", "key"_a = encode(key), //
+                        "opt_equal"_a = value ? "=" : "", "value"_a = value ? encode(value.value()) : "");
+            }
+
+            return fmt::format("{scheme}{colon}{opt_auth_slash}{authority}{opt_path_slash}{path}{qMark}{query}{hashMark}{fragment}",   //
+                    "scheme"_a = _scheme, "colon"_a = _scheme.empty() ? "" : ":",                                                      // scheme
+                    "opt_auth_slash"_a = (_authority.empty() || _authority.starts_with("//")) ? "" : "//", "authority"_a = _authority, // authority
+                    "opt_path_slash"_a = (_path.empty() || _path.starts_with('/') || _authority.empty()) ? "" : "/", "path"_a = _path, // path
+                    "qMark"_a = (_query.empty() || _query.starts_with('?')) ? "" : "?", "query"_a = _query,                            // query
+                    "hashMark"_a = (_fragment.empty() || _fragment.starts_with('#')) ? "" : "#", "fragment"_a = encode(_fragment));    // fragment
+        }
+
+        URI build() {
+            return URI<check>(toString());
+        }
+    };
+
+    static inline UriFactory factory() noexcept { return UriFactory(); }
+    static inline UriFactory factory(const URI &uri) noexcept { return UriFactory(uri); }
+
+private:
+    inline const std::optional<std::string> returnOpt(const string_view &src) const noexcept { // simple optional un-wrapper
+        if (!src.empty()) {
+            assert(src.data() >= str.data() && src.data() < str.data() + str.size());
+        }
+        return src.empty() ? std::nullopt : std::optional<std::string>(src);
+    };
+
+    inline void parseURI() {
         string_view source(str.c_str(), str.size());
         if constexpr (check == STRICT) {
             constexpr auto validURICharacters = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~:/?#[]@!$&'()*+,;=%";
@@ -111,7 +317,7 @@ public:
         // check for scheme
         size_t       scheme_size   = source.find_first_of(':', 0);
         const size_t nextSeparator = source.find_first_of("/?#", 0);
-        if (scheme_size < nextSeparator && scheme_size != string::npos) {
+        if (scheme_size < nextSeparator && scheme_size != std::string::npos) {
             _scheme = source.substr(0, scheme_size);
             if constexpr (check == STRICT) {
                 if (!std::all_of(_scheme.begin(), _scheme.end(), [](char c) { return std::isalnum(c); })) {
@@ -176,204 +382,35 @@ public:
         }
     }
 
-    URI(const URI &other)
-        : str(other.str), _parsedAuthority(other._parsedAuthority), _queryMap(other._queryMap) {
-        auto adjustedView = [this, &other](std::string_view otherView) {
-            return std::string_view(
-                    str.data() + std::distance(other.str.data(), otherView.data()),
-                    otherView.size());
-        };
-        _scheme    = adjustedView(other._scheme);
-        _authority = adjustedView(other._authority);
-        _userName  = adjustedView(other._userName);
-        _pwd       = adjustedView(other._pwd);
-        _hostName  = adjustedView(other._hostName);
-        _port      = adjustedView(other._port);
-        _path      = adjustedView(other._path);
-        _query     = adjustedView(other._query);
-        _fragment  = adjustedView(other._fragment);
+    // returns tif only RFC 3986 section 2.3 Unreserved Characters
+    static constexpr inline bool isUnreserved(const char c) noexcept { return std::isalnum(c) || c == '-' || c == '_' || c == '.' || c == '~'; }
+    constexpr inline void        parseAuthority() const {
+               if (_parsedAuthority || _authority.empty()) {
+                   _parsedAuthority = true;
+                   return;
+        }
+               size_t userSplit = std::min(_authority.find_first_of('@'), _authority.length());
+               if (userSplit < _authority.length()) {
+                   // user isUnreserved defined via '[user]:[pwd]@'
+            const size_t pwdSplit = std::min(_authority.find_first_of(':'), userSplit);
+            _userName             = _authority.substr(0, pwdSplit);
+            if (pwdSplit < userSplit) {
+                       _pwd = _authority.substr(pwdSplit + 1, userSplit - pwdSplit - 1);
+            }
+            userSplit++;
+        } else {
+                   userSplit = 0;
+        }
+               size_t portSplit = std::min(_authority.find_first_of(':', userSplit), _authority.length());
+               if (portSplit != string_view::npos && portSplit < _authority.length()) {
+                   // port defined
+            _hostName = _authority.substr(userSplit, portSplit - userSplit);
+            portSplit++;
+            _port = _authority.substr(portSplit, _authority.length() - portSplit);
+        } else {
+                   _hostName = _authority.substr(userSplit, _authority.length() - userSplit);
+        }
     }
-
-    URI               &operator=(const URI &other) = delete;
-
-    bool               empty() const { return str.empty(); }
-
-    static std::string encode(const std::string_view &source) noexcept {
-        std::ostringstream encoded;
-        encoded.fill('0');
-        encoded << std::hex;
-
-        for (auto c : source) {
-            if (isUnreserved(c)) {
-                // keep RFC 3986 section 2.3 Unreserved Characters i.e. [a-zA-Z0-9-_-~]
-                encoded << c;
-            } else {
-                // percent-encode RFC 3986 section 2.2 Reserved Characters i.e. [!#$%&'()*+,/:;=?@[]]
-                encoded << std::uppercase;
-                encoded << '%' << std::setw(2) << int(static_cast<uint8_t>(c));
-                encoded << std::nouppercase;
-            }
-        }
-
-        return encoded.str();
-    }
-
-    static std::string decode(const std::string_view &s) {
-        std::ostringstream decoded;
-        for (size_t i = 0; i < s.size(); ++i) {
-            char c = s[i];
-            if (c == '%') {
-                // percent-encode RFC 3986 section 2.2 Reserved Characters i.e. [!#$%&'()*+,/:;=?@[]]
-                if constexpr (check == STRICT) {
-                    if (!std::isxdigit(s[i + 1])) {
-                        throw URISyntaxException(fmt::format("additional erroneous character '{}' found after '%' at {} of '{}'", s[i + 1], i + 1, s));
-                    }
-                }
-                int                d;
-                std::istringstream iss(string(s.substr(i + 1, 2))); // TODO find smarter conversion
-                iss >> std::hex >> d;
-                decoded << static_cast<uint8_t>(d);
-                i += 2;
-            } else {
-                decoded << c;
-            }
-        }
-        return decoded.str();
-    }
-
-    // clang-format off
-    inline const std::optional<string> scheme() const noexcept { return returnOpt(_scheme); }
-    inline const std::optional<string> authority() const noexcept { return returnOpt(_authority); }
-    inline const std::optional<string> user() const noexcept { parseAuthority(); return returnOpt(_userName); }
-    inline const std::optional<string> password() const noexcept { parseAuthority(); return returnOpt(_pwd); }
-    inline const std::optional<string> hostName() const noexcept { parseAuthority(); return returnOpt(_hostName); }
-    inline const std::optional<uint16_t> port() const noexcept { parseAuthority(); return _port.empty() ? std::nullopt : std::optional(std::stoi(string{ _port.begin(), _port.end() }));}
-    inline const std::optional<string> path() const noexcept { return returnOpt(_path); }
-    inline const std::optional<string> queryParam() const noexcept { return returnOpt(_query); }
-    inline const std::optional<string> fragment() const noexcept { return returnOpt(_fragment); }
-    // clang-format om
-
-    // decompose map
-    inline const std::unordered_map<string, std::optional<string>> &queryParamMap() const {
-        if (_query.empty() || !_queryMap.empty()) { // empty query parameter or already parsed
-            return _queryMap;
-        }
-        if constexpr (check == STRICT) {
-            if (!std::all_of(_query.begin(), _query.end(), [](char c) { return isUnreserved(c) || c == '&' || c == ';' || c == '=' || c == '%' || c == ':' || c == '/'; })) {
-                throw URISyntaxException(fmt::format("URI query contains illegal characters: {}", _query));
-            }
-        }
-        size_t readPos = 0;
-        while (readPos < _query.length()) {
-            auto keyEnd = _query.find_first_of("=;&\0", readPos);
-            if (keyEnd != string_view::npos && keyEnd < _query.length()) {
-                auto key = decode(_query.substr(readPos, keyEnd - readPos));
-                if (_query[keyEnd] != '=') {
-                    _queryMap[key] = std::nullopt;
-                    readPos        = keyEnd + 1; //+1 for separator character
-                    continue;
-                }
-                readPos = keyEnd + 1; // skip equal after '='
-                // equal sign present
-                if (readPos >= _query.length()) {
-                    // reached parameter string end
-                    _queryMap[key] = std::nullopt;
-                    break;
-                }
-                const auto valueEnd = _query.find_first_of(";&\0", readPos);
-                if (valueEnd != string_view::npos && valueEnd < _query.length()) {
-                    _queryMap[key] = std::optional(decode(_query.substr(readPos, valueEnd - readPos)));
-                    readPos        = valueEnd + 1;
-                    continue;
-                }
-                const auto value = decode(_query.substr(readPos, _query.length() - readPos));
-                _queryMap[key] = value.empty() ? std::nullopt : std::optional(value);
-                break;
-            } else {
-                auto key       = std::string(_query.substr(readPos, _query.length() - readPos));
-                _queryMap[key] = std::nullopt;
-                break;
-            }
-        }
-
-        return _queryMap;
-    };
-
-    // comparison operators
-    auto operator<=>(const URI &other) const noexcept { return str <=> other.str; }
-    bool operator==(const URI &other) const noexcept  { return str == other.str; }
-
-    class UriFactory {
-        string                  _authority;
-        string                  _scheme;
-        string                  _userName;
-        string                  _pwd;
-        string                  _host;
-        std::optional<uint16_t> _port;
-        string                  _path;
-        string                  _query;
-        string                  _fragment;
-        // local map to overwrite _query parameter if set
-        std::unordered_map<string, std::optional<string>> _queryMap;
-
-    public:
-        UriFactory() = default;
-        // clang-format off
-        explicit UriFactory(const URI &uri) {
-            if (!uri._scheme.empty())    { _scheme = uri._scheme; }
-            if (!uri._authority.empty()) { _authority = uri._authority; }
-            if (!uri._userName.empty())  { _userName = uri._userName; }
-            if (!uri._pwd.empty())       { _pwd = uri._pwd; }
-            if (!uri._hostName.empty())  { _host = uri._hostName; }
-            if (!uri._port.empty())      { _port = std::stoi(std::string(uri._port)); }
-            if (!uri._path.empty())      { _path = uri._path; }
-            if (!uri._query.empty())     { _query = uri._query; }
-            if (!uri._fragment.empty())  { _fragment = uri._fragment; }
-        }
-        inline UriFactory&& scheme(const std::string_view &scheme)        && noexcept { _scheme = scheme; return std::move(*this); }
-        inline UriFactory&& authority(const std::string_view &authority)  && noexcept { _authority = { authority.begin(), authority.end() }; return std::move(*this); }
-        inline UriFactory&& user(const std::string_view &userName)        && noexcept { _userName = { userName.begin(), userName.end() }; return std::move(*this); }
-        inline UriFactory&& password(const std::string_view &pwd)         && noexcept { _pwd = { pwd.begin(), pwd.end() }; return std::move(*this); }
-        inline UriFactory&& hostName(const std::string_view &hostName)    && noexcept { _host = { hostName.begin(), hostName.end() }; return std::move(*this); }
-        inline UriFactory&& port(const uint16_t port)                     && noexcept { _port = std::optional<uint16_t>(port); return std::move(*this); }
-        inline UriFactory&& path(const std::string_view &path)            && noexcept { _path = { path.begin(), path.end() }; return std::move(*this); }
-        inline UriFactory&& queryParam(const std::string_view &query)     && noexcept { _query = { query.begin(), query.end() }; return std::move(*this); }
-        inline UriFactory&& fragment(const std::string_view &fragment)    && noexcept { _fragment = { fragment.begin(), fragment.end() }; return std::move(*this); }
-        inline UriFactory&& addQueryParameter(const std::string &key)     && noexcept { _queryMap[key] = std::nullopt; return std::move(*this); }
-        inline UriFactory&& addQueryParameter(const std::string &key, const std::string &value) && noexcept { _queryMap[key] = std::optional(value); return std::move(*this); }
-        inline UriFactory&& setQuery(std::unordered_map<std::string, std::optional<std::string>> queryMap) && noexcept { _query.clear(); _queryMap = std::move(queryMap); return std::move(*this); }
-        // clang-format on
-
-        std::string toString() {
-            using namespace fmt::literals;
-            if (_authority.empty()) {
-                _authority = fmt::format("{user}{opt_colon1}{pwd}{at}{host}{opt_colon2}{port}",                //
-                        "user"_a = _userName, "opt_colon1"_a = (_pwd.empty() || _userName.empty()) ? "" : ":", /* user:pwd colon separator */
-                        "pwd"_a = _userName.empty() ? "" : _pwd, "at"_a = _userName.empty() ? "" : "@",        // 'user:pwd@' separator
-                        "host"_a = _host, "opt_colon2"_a = _port ? ":" : "", "port"_a = _port ? std::to_string(_port.value()) : "");
-            }
-
-            for (const auto &[key, value] : _queryMap) {
-                _query += fmt::format("{opt_ampersand}{key}{opt_equal}{value}",               // N.B. 'key=value' percent-encoding according to RFC 3986
-                        "opt_ampersand"_a = _query.empty() ? "" : "&", "key"_a = encode(key), //
-                        "opt_equal"_a = value ? "=" : "", "value"_a = value ? encode(value.value()) : "");
-            }
-
-            return fmt::format("{scheme}{colon}{opt_auth_slash}{authority}{opt_path_slash}{path}{qMark}{query}{hashMark}{fragment}",   //
-                    "scheme"_a = _scheme, "colon"_a = _scheme.empty() ? "" : ":",                                                      // scheme
-                    "opt_auth_slash"_a = (_authority.empty() || _authority.starts_with("//")) ? "" : "//", "authority"_a = _authority, // authority
-                    "opt_path_slash"_a = (_path.empty() || _path.starts_with('/') || _authority.empty()) ? "" : "/", "path"_a = _path, // path
-                    "qMark"_a = (_query.empty() || _query.starts_with('?')) ? "" : "?", "query"_a = _query,                            // query
-                    "hashMark"_a = (_fragment.empty() || _fragment.starts_with('#')) ? "" : "#", "fragment"_a = encode(_fragment));    // fragment
-        }
-
-        URI build() {
-            return URI<check>(toString());
-        }
-    };
-
-    static inline UriFactory factory() noexcept { return UriFactory(); }
-    static inline UriFactory factory(const URI &uri) noexcept { return UriFactory(uri); }
 };
 } // namespace opencmw
 
@@ -394,7 +431,7 @@ struct fmt::formatter<std::optional<T>> {
 
     template<typename FormatContext>
     auto format(std::optional<T> const &v, FormatContext &ctx) {
-        return v ? fmt::format_to(ctx.out(), "{}", v.value()) : fmt::format_to(ctx.out(), "<std::nullopt>"); // TODO: check alt of '<>' or ''
+        return v ? fmt::format_to(ctx.out(), "{}", v.value()) : fmt::format_to(ctx.out(), "<std::nullopt>");
     }
 };
 

--- a/src/majordomo/include/majordomo/Broker.hpp
+++ b/src/majordomo/include/majordomo/Broker.hpp
@@ -187,8 +187,8 @@ private:
         std::size_t                                    requestCount       = 0;
 
         auto                                          &queueForRole(const std::string_view role) {
-                                                     auto it = std::find_if(requestsByPriority.begin(), requestsByPriority.end(), [&role](const auto &v) { return v.first == role; });
-                                                     return it != requestsByPriority.end() ? it->second : requestsByPriority.back().second;
+            auto it = std::find_if(requestsByPriority.begin(), requestsByPriority.end(), [&role](const auto &v) { return v.first == role; });
+            return it != requestsByPriority.end() ? it->second : requestsByPriority.back().second;
         }
 
         explicit Service(std::string name_, std::string description_)
@@ -351,7 +351,7 @@ public:
         pollerItems[3].events = ZMQ_POLLIN;
     }
 
-    Broker(const Broker &)            = delete;
+    Broker(const Broker &) = delete;
     Broker &operator=(const Broker &) = delete;
 
     template<typename Filter>

--- a/src/majordomo/include/majordomo/Broker.hpp
+++ b/src/majordomo/include/majordomo/Broker.hpp
@@ -105,7 +105,7 @@ inline bool iequal(const Left &left, const Right &right) noexcept {
 }
 
 inline std::string uriAsString(const URI<RELAXED> &uri) {
-    return uri.str;
+    return uri.str();
 }
 
 inline std::string findDnsEntry(std::string_view brokerName, std::unordered_map<std::string, detail::DnsServiceItem> &dnsCache, std::string_view s) {
@@ -187,8 +187,8 @@ private:
         std::size_t                                    requestCount       = 0;
 
         auto                                          &queueForRole(const std::string_view role) {
-            auto it = std::find_if(requestsByPriority.begin(), requestsByPriority.end(), [&role](const auto &v) { return v.first == role; });
-            return it != requestsByPriority.end() ? it->second : requestsByPriority.back().second;
+                                                     auto it = std::find_if(requestsByPriority.begin(), requestsByPriority.end(), [&role](const auto &v) { return v.first == role; });
+                                                     return it != requestsByPriority.end() ? it->second : requestsByPriority.back().second;
         }
 
         explicit Service(std::string name_, std::string description_)
@@ -324,21 +324,21 @@ public:
         // socket.setHeartbeatContext(PROT_CLIENT.getData());
 
         initializeZmqSocket(_routerSocket, settings).assertSuccess();
-        zmq_invoke(zmq_bind, _routerSocket, INTERNAL_ADDRESS_BROKER.str.data()).assertSuccess();
+        zmq_invoke(zmq_bind, _routerSocket, INTERNAL_ADDRESS_BROKER.str().data()).assertSuccess();
 
         initializeZmqSocket(_subSocket, settings).assertSuccess();
-        zmq_invoke(zmq_bind, _subSocket, INTERNAL_ADDRESS_SUBSCRIBE.str.data()).assertSuccess();
+        zmq_invoke(zmq_bind, _subSocket, INTERNAL_ADDRESS_SUBSCRIBE.str().data()).assertSuccess();
 
         initializeZmqSocket(_pubSocket, settings).assertSuccess();
         int verbose = 1;
         zmq_invoke(zmq_setsockopt, _pubSocket, ZMQ_XPUB_VERBOSE, &verbose, sizeof(verbose)).assertSuccess();
-        zmq_invoke(zmq_bind, _pubSocket, INTERNAL_ADDRESS_PUBLISHER.str.data()).assertSuccess();
+        zmq_invoke(zmq_bind, _pubSocket, INTERNAL_ADDRESS_PUBLISHER.str().data()).assertSuccess();
 
         initializeZmqSocket(_dnsSocket, settings).assertSuccess();
         if (!settings.dnsAddress.empty()) {
             zmq_invoke(zmq_connect, _dnsSocket, toZeroMQEndpoint(URI<>(settings.dnsAddress)).data()).assertSuccess();
         } else {
-            zmq_invoke(zmq_connect, _dnsSocket, INTERNAL_ADDRESS_BROKER.str.data()).assertSuccess();
+            zmq_invoke(zmq_connect, _dnsSocket, INTERNAL_ADDRESS_BROKER.str().data()).assertSuccess();
         }
 
         pollerItems[0].socket = _routerSocket.zmq_ptr;
@@ -351,7 +351,7 @@ public:
         pollerItems[3].events = ZMQ_POLLIN;
     }
 
-    Broker(const Broker &) = delete;
+    Broker(const Broker &)            = delete;
     Broker &operator=(const Broker &) = delete;
 
     template<typename Filter>
@@ -388,7 +388,7 @@ public:
                                                                               : URI<STRICT>::factory(endpoint).scheme(isRouterSocket ? SCHEME_MDP : SCHEME_MDS).build();
         const auto adjustedAddressPublic = endpointAdjusted; // TODO (java) resolveHost(endpointAdjusted, getLocalHostName());
 
-        _dnsAddresses.insert(adjustedAddressPublic.str);
+        _dnsAddresses.insert(adjustedAddressPublic.str());
         sendDnsHeartbeats(true);
         return adjustedAddressPublic;
     }
@@ -445,9 +445,9 @@ public:
 
     void registerDnsAddress(const opencmw::URI<> &address) {
         // worker registers a new address for this broker (used the REST interface)
-        _dnsAddresses.insert(address.str);
+        _dnsAddresses.insert(address.str());
         auto [iter, inserted] = _dnsCache.try_emplace(brokerName, std::string(), brokerName);
-        iter->second.uris.insert(URI<RELAXED>(address.str));
+        iter->second.uris.insert(URI<RELAXED>(address.str()));
         sendDnsHeartbeats(true);
     }
 
@@ -463,7 +463,7 @@ private:
         auto [it, inserted] = _subscribedTopics.try_emplace(topic, 0);
         it->second++;
         if (it->second == 1) {
-            zmq_invoke(zmq_setsockopt, _subSocket, ZMQ_SUBSCRIBE, topic.str.data(), topic.str.size()).assertSuccess();
+            zmq_invoke(zmq_setsockopt, _subSocket, ZMQ_SUBSCRIBE, topic.str().data(), topic.str().size()).assertSuccess();
         }
     }
 
@@ -472,7 +472,7 @@ private:
         if (it != _subscribedTopics.end()) {
             it->second--;
             if (it->second == 0) {
-                zmq_invoke(zmq_setsockopt, _subSocket, ZMQ_UNSUBSCRIBE, topic.str.data(), topic.str.size()).assertSuccess();
+                zmq_invoke(zmq_setsockopt, _subSocket, ZMQ_UNSUBSCRIBE, topic.str().data(), topic.str().size()).assertSuccess();
             }
         }
     }
@@ -636,7 +636,7 @@ private:
             if (_subscriptionMatcher(topicURI, topic)) {
                 // sends notification with the topic that is expected by the client for its subscription
                 auto copy = message.clone();
-                copy.setSourceId(topic.str, MessageFrame::dynamic_bytes_tag{});
+                copy.setSourceId(topic.str(), MessageFrame::dynamic_bytes_tag{});
                 copy.send(_pubSocket).assertSuccess();
             }
         }
@@ -701,7 +701,7 @@ private:
             constexpr auto dynamic_tag = MessageFrame::dynamic_bytes_tag{};
             constexpr auto static_tag  = MessageFrame::static_bytes_tag{};
             reply.setCommand(Command::Final);
-            reply.setTopic(INTERNAL_SERVICE_NAMES_URI.str, static_tag);
+            reply.setTopic(INTERNAL_SERVICE_NAMES_URI.str(), static_tag);
             reply.setBody("", static_tag);
             reply.setError(fmt::format("unknown service (error 501): '{}'", reply.serviceName()), dynamic_tag);
             reply.setRbacToken(_rbac, static_tag);
@@ -787,7 +787,7 @@ private:
             auto       notify      = BrokerMessage::createWorkerMessage(Command::Notify);
             const auto dynamic_tag = MessageFrame::dynamic_bytes_tag{};
             notify.setServiceName(INTERNAL_SERVICE_NAMES, dynamic_tag);
-            notify.setTopic(INTERNAL_SERVICE_NAMES_URI.str, dynamic_tag);
+            notify.setTopic(INTERNAL_SERVICE_NAMES_URI.str(), dynamic_tag);
             notify.setClientRequestId(brokerName, dynamic_tag);
             notify.setSourceId(INTERNAL_SERVICE_NAMES, dynamic_tag);
             notify.send(_pubSocket).assertSuccess();

--- a/src/majordomo/include/majordomo/RestBackend.hpp
+++ b/src/majordomo/include/majordomo/RestBackend.hpp
@@ -108,8 +108,8 @@ protected:
             , subscriber(broker.context, ZMQ_SUB) {
             pollItem.events = ZMQ_POLLIN;
 
-            zmq_invoke(zmq_connect, dealer, INTERNAL_ADDRESS_BROKER.str).onFailure<opencmw::startup_error>("Can not connect REST worker to Majordomo broker");
-            zmq_invoke(zmq_connect, subscriber, INTERNAL_ADDRESS_PUBLISHER.str).onFailure<opencmw::startup_error>("Can not connect REST worker to Majordomo broker");
+            zmq_invoke(zmq_connect, dealer, INTERNAL_ADDRESS_BROKER.str()).onFailure<opencmw::startup_error>("Can not connect REST worker to Majordomo broker");
+            zmq_invoke(zmq_connect, subscriber, INTERNAL_ADDRESS_PUBLISHER.str()).onFailure<opencmw::startup_error>("Can not connect REST worker to Majordomo broker");
         }
 
         RestWorker(RestWorker &&other) = default;
@@ -407,7 +407,7 @@ public:
         registerHandlers();
 
         if (!_restAddress.hostName() || !_restAddress.port()) {
-            throw opencmw::startup_error(fmt::format("REST server URI is not valid {}", _restAddress.str));
+            throw opencmw::startup_error(fmt::format("REST server URI is not valid {}", _restAddress.str()));
         }
 
         bool listening = _svr.listen(_restAddress.hostName().value().data(), _restAddress.port().value());

--- a/src/majordomo/include/majordomo/Utils.hpp
+++ b/src/majordomo/include/majordomo/Utils.hpp
@@ -13,7 +13,7 @@ inline std::string toZeroMQEndpoint(const opencmw::URI<> &uri) {
         return opencmw::URI<>::factory(uri).scheme("tcp").toString();
     }
 
-    return uri.str;
+    return uri.str();
 }
 
 inline Result<int> initializeZmqSocket(const majordomo::Socket &sock, const majordomo::Settings &settings = {}) {

--- a/src/majordomo/include/majordomo/Worker.hpp
+++ b/src/majordomo/include/majordomo/Worker.hpp
@@ -334,32 +334,32 @@ private:
     static constexpr auto _defaultPermission = _permissionsByRole.data.back().second;
 
     MdpMessage            processRequest(MdpMessage &&request) noexcept {
-        const auto clientRole = parse_rbac::role(request.rbacToken());
-        const auto permission = _permissionsByRole.at(clientRole, _defaultPermission);
+                   const auto clientRole = parse_rbac::role(request.rbacToken());
+                   const auto permission = _permissionsByRole.at(clientRole, _defaultPermission);
 
-        if (request.command() == Command::Get && !(permission == Permission::RW || permission == Permission::RO)) {
-            auto errorReply = replyFromRequest(request);
-            errorReply.setError(fmt::format("GET access denied to role '{}'", clientRole), MessageFrame::dynamic_bytes_tag{});
-            return errorReply;
+                   if (request.command() == Command::Get && !(permission == Permission::RW || permission == Permission::RO)) {
+                       auto errorReply = replyFromRequest(request);
+                       errorReply.setError(fmt::format("GET access denied to role '{}'", clientRole), MessageFrame::dynamic_bytes_tag{});
+                       return errorReply;
         } else if (request.command() == Command::Set && !(permission == Permission::RW || permission == Permission::WO)) {
-            auto errorReply = replyFromRequest(request);
-            errorReply.setError(fmt::format("SET access denied to role '{}'", clientRole), MessageFrame::dynamic_bytes_tag{});
-            return errorReply;
+                       auto errorReply = replyFromRequest(request);
+                       errorReply.setError(fmt::format("SET access denied to role '{}'", clientRole), MessageFrame::dynamic_bytes_tag{});
+                       return errorReply;
         }
 
-        RequestContext context{ .request = std::move(request), .reply = replyFromRequest(context.request) };
+                   RequestContext context{ .request = std::move(request), .reply = replyFromRequest(context.request) };
 
-        try {
-            std::invoke(_handler, context);
-            return std::move(context.reply);
+                   try {
+                       std::invoke(_handler, context);
+                       return std::move(context.reply);
         } catch (const std::exception &e) {
-            auto errorReply = replyFromRequest(context.request);
-            errorReply.setError(fmt::format("Caught exception for service '{}'\nrequest message: {}\nexception: {}", serviceName.data(), context.request.body(), e.what()), MessageFrame::dynamic_bytes_tag{});
-            return errorReply;
+                       auto errorReply = replyFromRequest(context.request);
+                       errorReply.setError(fmt::format("Caught exception for service '{}'\nrequest message: {}\nexception: {}", serviceName.data(), context.request.body(), e.what()), MessageFrame::dynamic_bytes_tag{});
+                       return errorReply;
         } catch (...) {
-            auto errorReply = replyFromRequest(context.request);
-            errorReply.setError(fmt::format("Caught unexpected exception for service '{}'\nrequest message: {}", serviceName.data(), context.request.body()), MessageFrame::dynamic_bytes_tag{});
-            return errorReply;
+                       auto errorReply = replyFromRequest(context.request);
+                       errorReply.setError(fmt::format("Caught unexpected exception for service '{}'\nrequest message: {}", serviceName.data(), context.request.body()), MessageFrame::dynamic_bytes_tag{});
+                       return errorReply;
         }
     }
 
@@ -448,7 +448,7 @@ inline void writeResult(std::string_view workerName, RequestContext &rawCtx, con
     const auto baseUri    = URI<RELAXED>(std::string(rawCtx.reply.topic().empty() ? rawCtx.request.topic() : rawCtx.reply.topic()));
     const auto topicUri   = URI<RELAXED>::factory(baseUri).setQuery(std::move(replyQuery)).build();
 
-    rawCtx.reply.setTopic(topicUri.str, MessageFrame::dynamic_bytes_tag{});
+    rawCtx.reply.setTopic(topicUri.str(), MessageFrame::dynamic_bytes_tag{});
     const auto replyMimetype = query::getMimeType(replyContext);
     const auto mimeType      = replyMimetype != MIME::UNKNOWN ? replyMimetype : rawCtx.mimeType;
     if (mimeType == MIME::JSON) {
@@ -478,7 +478,7 @@ inline void writeResultFull(std::string_view workerName, RequestContext &rawCtx,
     const auto baseUri    = URI<RELAXED>(std::string(rawCtx.reply.topic().empty() ? rawCtx.request.topic() : rawCtx.reply.topic()));
     const auto topicUri   = URI<RELAXED>::factory(baseUri).setQuery(std::move(replyQuery)).build();
 
-    rawCtx.reply.setTopic(topicUri.str, MessageFrame::dynamic_bytes_tag{});
+    rawCtx.reply.setTopic(topicUri.str(), MessageFrame::dynamic_bytes_tag{});
     const auto replyMimetype = query::getMimeType(replyContext);
     const auto mimeType      = replyMimetype != MIME::UNKNOWN ? replyMimetype : rawCtx.mimeType;
     if (mimeType == MIME::JSON) {
@@ -583,7 +583,7 @@ public:
         // TODO java does subscription handling here which BasicMdpWorker does in the sender thread. check what we need there.
 
         RequestContext rawCtx;
-        rawCtx.reply.setTopic(topicURI.str, MessageFrame::dynamic_bytes_tag{});
+        rawCtx.reply.setTopic(topicURI.str(), MessageFrame::dynamic_bytes_tag{});
         worker_detail::writeResult(Worker::name, rawCtx, context, reply);
         return BasicWorker<serviceName, Meta...>::notify(std::move(rawCtx.reply));
     }

--- a/src/majordomo/include/majordomo/Worker.hpp
+++ b/src/majordomo/include/majordomo/Worker.hpp
@@ -334,32 +334,32 @@ private:
     static constexpr auto _defaultPermission = _permissionsByRole.data.back().second;
 
     MdpMessage            processRequest(MdpMessage &&request) noexcept {
-                   const auto clientRole = parse_rbac::role(request.rbacToken());
-                   const auto permission = _permissionsByRole.at(clientRole, _defaultPermission);
+        const auto clientRole = parse_rbac::role(request.rbacToken());
+        const auto permission = _permissionsByRole.at(clientRole, _defaultPermission);
 
-                   if (request.command() == Command::Get && !(permission == Permission::RW || permission == Permission::RO)) {
-                       auto errorReply = replyFromRequest(request);
-                       errorReply.setError(fmt::format("GET access denied to role '{}'", clientRole), MessageFrame::dynamic_bytes_tag{});
-                       return errorReply;
+        if (request.command() == Command::Get && !(permission == Permission::RW || permission == Permission::RO)) {
+            auto errorReply = replyFromRequest(request);
+            errorReply.setError(fmt::format("GET access denied to role '{}'", clientRole), MessageFrame::dynamic_bytes_tag{});
+            return errorReply;
         } else if (request.command() == Command::Set && !(permission == Permission::RW || permission == Permission::WO)) {
-                       auto errorReply = replyFromRequest(request);
-                       errorReply.setError(fmt::format("SET access denied to role '{}'", clientRole), MessageFrame::dynamic_bytes_tag{});
-                       return errorReply;
+            auto errorReply = replyFromRequest(request);
+            errorReply.setError(fmt::format("SET access denied to role '{}'", clientRole), MessageFrame::dynamic_bytes_tag{});
+            return errorReply;
         }
 
-                   RequestContext context{ .request = std::move(request), .reply = replyFromRequest(context.request) };
+        RequestContext context{ .request = std::move(request), .reply = replyFromRequest(context.request) };
 
-                   try {
-                       std::invoke(_handler, context);
-                       return std::move(context.reply);
+        try {
+            std::invoke(_handler, context);
+            return std::move(context.reply);
         } catch (const std::exception &e) {
-                       auto errorReply = replyFromRequest(context.request);
-                       errorReply.setError(fmt::format("Caught exception for service '{}'\nrequest message: {}\nexception: {}", serviceName.data(), context.request.body(), e.what()), MessageFrame::dynamic_bytes_tag{});
-                       return errorReply;
+            auto errorReply = replyFromRequest(context.request);
+            errorReply.setError(fmt::format("Caught exception for service '{}'\nrequest message: {}\nexception: {}", serviceName.data(), context.request.body(), e.what()), MessageFrame::dynamic_bytes_tag{});
+            return errorReply;
         } catch (...) {
-                       auto errorReply = replyFromRequest(context.request);
-                       errorReply.setError(fmt::format("Caught unexpected exception for service '{}'\nrequest message: {}", serviceName.data(), context.request.body()), MessageFrame::dynamic_bytes_tag{});
-                       return errorReply;
+            auto errorReply = replyFromRequest(context.request);
+            errorReply.setError(fmt::format("Caught unexpected exception for service '{}'\nrequest message: {}", serviceName.data(), context.request.body()), MessageFrame::dynamic_bytes_tag{});
+            return errorReply;
         }
     }
 

--- a/src/majordomo/test/majordomo_benchmark.cpp
+++ b/src/majordomo/test/majordomo_benchmark.cpp
@@ -169,7 +169,7 @@ void simpleTwoWorkerBenchmark(const URI &routerAddress, Get mode, int iterations
     const std::chrono::duration<double> diff  = after - before;
 
     std::cout << fmt::format("{}: {}. Alternating Payloads {}/{} bytes: {} iterations took {}s ({} messages/s)\n",
-            routerAddress.str,
+            routerAddress,
             mode == Get::Async ? "ASYNC" : "SYNC",
             payload1_size,
             payload2_size,
@@ -195,7 +195,7 @@ int main(int argc, char **argv) {
 
     for (const auto &result : results) {
         std::cout << fmt::format("{}: {}. Payload {} bytes: {} iterations took {}s ({} messages/s)\n",
-                result.routerAddress.str,
+                result.routerAddress,
                 result.mode == Get::Async ? "ASYNC" : "SYNC",
                 result.payloadSize,
                 result.iterations,

--- a/src/majordomo/test/majordomo_tests.cpp
+++ b/src/majordomo/test/majordomo_tests.cpp
@@ -170,7 +170,7 @@ TEST_CASE("Test mmi.dns", "[broker][mmi][mmi_dns]") {
     const auto brokerAddress   = opencmw::URI<opencmw::STRICT>("mdp://127.0.0.1:22346");
     Broker     dnsBroker("dnsBroker", settings);
     REQUIRE(dnsBroker.bind(dnsAddress));
-    settings.dnsAddress = dnsAddress.str;
+    settings.dnsAddress = dnsAddress.str();
     Broker broker("testbroker", settings);
     REQUIRE(broker.bind(brokerAddress));
 
@@ -1111,7 +1111,7 @@ TEST_CASE("BasicWorker run loop quits when broker quits", "[worker]") {
     auto                     quitBroker = std::jthread([&broker]() {
         std::this_thread::sleep_for(std::chrono::milliseconds(250));
         broker.shutdown();
-                        });
+    });
 
     worker.run(); // returns when broker disappears
     quitBroker.join();

--- a/src/majordomo/test/majordomo_tests.cpp
+++ b/src/majordomo/test/majordomo_tests.cpp
@@ -1111,7 +1111,7 @@ TEST_CASE("BasicWorker run loop quits when broker quits", "[worker]") {
     auto                     quitBroker = std::jthread([&broker]() {
         std::this_thread::sleep_for(std::chrono::milliseconds(250));
         broker.shutdown();
-    });
+                        });
 
     worker.run(); // returns when broker disappears
     quitBroker.join();


### PR DESCRIPTION
follow-up of issue #181 only and does not include #185:

We presently have de-factor two MdpMessage definitions implementing OpenCMW's [Majordomo Protocol](https://github.com/fair-acc/opencmw-cpp/blob/main/docs/Majordomo_protocol_comparison.pdf) stack:
 a) this [one](https://github.com/fair-acc/opencmw-cpp/blob/main/src/majordomo/include/majordomo/Message.hpp) implementing the full stack, being based on ZeroMQ's `ZMzg`/`ZFrame`, and being widely used in the Majordomo Broker/Worker, and 
 b) this [partial RawMessage implementation](https://github.com/fair-acc/opencmw-cpp/blob/main/src/client/include/ClientContext.hpp#L22-L28) being used the Client.

The plan is to replace the `std::vector<std::byte>` with the new more versatile `IoBuffer` wrapper implementation that depends only on stdlib-C++ and should minimise the maintenance effort on the long-run.

However, the merging of the different implementations `a)` and `b)` is deliberately left as a future enhancement.
