### PR TITLE
Add header for cross access

### DIFF
--- a/src/majordomo/include/majordomo/RestBackend.hpp
+++ b/src/majordomo/include/majordomo/RestBackend.hpp
@@ -357,6 +357,7 @@ public:
 
             response.set_header("X-OPENCMW-TOPIC", responseMessage->topic().data());
             response.set_header("X-OPENCMW-SERVICE-NAME", responseMessage->serviceName().data());
+            response.set_header("Access-Control-Allow-Origin", "*");
 
             if (request.method != "GET") {
                 response.set_content(responseMessage->body().data(), MIME::TEXT.typeName().data());


### PR DESCRIPTION
The header file did not provide access control allowance so that responds can be shared with requesting code. Further information on Access-Control-Allow-Origin can be found [here](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Origin).