### PR TITLE
Add support for HTTP OPTIONS preflight request

### DIFF
--- a/src/majordomo/include/majordomo/RestBackend.hpp
+++ b/src/majordomo/include/majordomo/RestBackend.hpp
@@ -337,6 +337,14 @@ public:
         _svr.Put(".*", [defaultHandler](const httplib::Request &request, httplib::Response &response, const httplib::ContentReader &content_reader) {
             return defaultHandler(request, response, &content_reader);
         });
+        _svr.Options(".*",
+                [](const httplib::Request & /*req*/, httplib::Response &res) {
+                    res.set_header("Allow", "GET, POST, PUT, OPTIONS");
+                    res.set_header("Access-Control-Allow-Origin", "*");
+                    res.set_header("Access-Control-Allow-Methods", "GET, POST, PUT, OPTIONS");
+                    res.set_header("Access-Control-Allow-Headers", "X-OPENCMW-METHOD");
+                    res.set_header("Access-Control-Max-Age", "86400");
+                });
     }
 
     void respondWithPubSub(auto &worker, auto &request, auto &response, auto &message) {
@@ -373,6 +381,7 @@ public:
 
         (void) service;
 
+        response.set_header("Access-Control-Allow-Origin", "*");
         response.set_chunked_content_provider(
                 "application/json",
                 [this, &worker, topic = topic, service = service, counter = std::size_t{ 0 }, maxCount](std::size_t /*offset*/, httplib::DataSink &sink) mutable {


### PR DESCRIPTION
To do long polling the opencmw rest protocol requires a special
X_OPENCMW_METHOD header which disables the simple CORS handling and
requires the server to respond to a pre-flight request [1].
This commit adds support for preflight requests allowing access with
the custom opencmw headers from any origin.
Builds up on #207, which allows simple CORS requests without the
headers.

This is not needed if the client html is served from the same origin
(protocol, host, port) which is why the problem is not happening with
the html based webinterface.

Additionally, the the `Acces-Control-Allow-Origin` header was only set
for get responses and not for subscription responses, which is also
fixed in this commit.

[1] https://developer.mozilla.org/en-US/docs/Glossary/Preflight_request