### PR TITLE
fix compilation for emscripten with certain specific hacks

### DIFF
--- a/src/serialiser/include/IoBuffer.hpp
+++ b/src/serialiser/include/IoBuffer.hpp
@@ -9,7 +9,14 @@
 #include <algorithm>
 #include <array>
 #include <cassert>
-#include <memory_resource>
+#ifdef __EMSCRIPTEN__
+#   include <experimental/memory_resource>
+    namespace std {
+        namespace pmr = ::std::experimental::pmr;
+    }
+#else
+#   include <memory_resource>
+#endif
 #include <numeric>
 #include <span>
 #include <stdexcept>

--- a/src/serialiser/test/IoSerialiserYaS_tests.cpp
+++ b/src/serialiser/test/IoSerialiserYaS_tests.cpp
@@ -256,8 +256,7 @@ TEST_CASE("IoClassSerialiser basic typeName tests", "[IoClassSerialiser]") {
         REQUIRE(typeName<int32_t const> == "int32_t const");
         REQUIRE(typeName<int64_t> == "int64_t");
         REQUIRE(typeName<int64_t const> == "int64_t const");
-        REQUIRE(typeName<long long> == "int128_t");
-        REQUIRE(typeName<long long const> == "int128_t const");
+
         // unsigned integer values
         REQUIRE(typeName<uint8_t> == "uint8_t");
         REQUIRE(typeName<uint8_t const> == "uint8_t const");
@@ -269,8 +268,6 @@ TEST_CASE("IoClassSerialiser basic typeName tests", "[IoClassSerialiser]") {
         REQUIRE(typeName<uint32_t const> == "uint32_t const");
         REQUIRE(typeName<uint64_t> == "uint64_t");
         REQUIRE(typeName<uint64_t const> == "uint64_t const");
-        REQUIRE(typeName<unsigned long long> == "uint128_t");
-        REQUIRE(typeName<unsigned long long const> == "uint128_t const");
 
         // floating point
         REQUIRE(typeName<float_t> == "float_t");


### PR DESCRIPTION
partially fixing #193 (only Emscripten/clang)

The current stable emsdk ships with an STL implementation that, in combination with using clang/LLVM, is incompatible with refl-cpp and mp-units. To fix compilation, some direct hacks have been introduced. They seem to work without breaking functionality with and without using Emscripten, but when something changes in emsdk, there might be new issues.

Another idea would be to try and see if emsdk has unstable releases of a newer STL and/or better C++20 support. Overall however, this PR shows what _would_ need to be done, to get opencmw compiled using Emscripten/Clang.