### PR TITLE
exposed _activeSubscriptions in BasicWorker

### DIFF
--- a/src/majordomo/test/majordomoworker_tests.cpp
+++ b/src/majordomo/test/majordomoworker_tests.cpp
@@ -194,7 +194,8 @@ TEST_CASE("MajordomoWorker test using raw messages", "[majordomo][majordomoworke
     TestNode<BrokerMessage> subClient(broker.context, ZMQ_SUB);
     REQUIRE(client.connect(opencmw::majordomo::INTERNAL_ADDRESS_BROKER));
     REQUIRE(subClient.connect(opencmw::majordomo::INTERNAL_ADDRESS_PUBLISHER));
-    REQUIRE(subClient.subscribe("/newAddress?ctx=FAIR.SELECTOR.C=1"));
+    const char *testSubscription = "/newAddress?ctx=FAIR.SELECTOR.C=1";
+    REQUIRE(subClient.subscribe(testSubscription));
 
     {
         auto request = MdpMessage::createClientMessage(Command::Get);
@@ -323,6 +324,8 @@ TEST_CASE("MajordomoWorker test using raw messages", "[majordomo][majordomoworke
             .city         = "Easter Island"
         };
         REQUIRE(worker.notify("/newAddress", TestContext{ .ctx = opencmw::TimingCtx(1), .contentType = opencmw::MIME::JSON }, entry));
+        REQUIRE(worker.activeSubscriptions().size() == 1);
+        REQUIRE(testSubscription == worker.activeSubscriptions().begin()->str());
     }
 
     {


### PR DESCRIPTION
should be thread-safe and allow for custom notification based on existing/known subscriptions.