### PR TITLE
Upgrade libfmt

### DIFF
--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -18,7 +18,7 @@ FetchContent_Declare(
 FetchContent_Declare(
         fmt
         GIT_REPOSITORY https://github.com/fmtlib/fmt.git
-        GIT_TAG        7.1.3 # newest: 8.1.1
+        GIT_TAG        8.1.1 # newest: 8.1.1
 )
 
 # dependency of mp-units, building examples, tests, etc is off by default

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -18,7 +18,7 @@ FetchContent_Declare(
 FetchContent_Declare(
         fmt
         GIT_REPOSITORY https://github.com/fmtlib/fmt.git
-        GIT_TAG        8.1.1 # newest: 8.1.1
+        GIT_TAG        8.1.1 # newest: 9.1.0
 )
 
 # dependency of mp-units, building examples, tests, etc is off by default

--- a/concepts/core/BasicThreadPool_example.cpp
+++ b/concepts/core/BasicThreadPool_example.cpp
@@ -20,9 +20,11 @@ int main() {
 
     // enqueue and add task to list -- w/o return type
     poolWork.execute([] { fmt::print("Hello World from thread '{}'!\n", getThreadName()); });
-    poolWork.execute([](const auto &...args) { fmt::print("Hello World from thread '{}'!\n", args...); }, getThreadName());
+    // poolWork.execute([]<typename... T>(T&&...args) { fmt::print(fmt::format_string<T...>("Hello World from thread '{}'!\n"), std::forward<T>(args)...); }, getThreadName());
+    poolWork.execute([](const auto &...args) { fmt::print(fmt::runtime("Hello World from thread '{}'!\n"), args...); }, getThreadName());
 
-    constexpr auto           func1  = [](const auto &...args) { return fmt::format("thread '{1}' scheduled task '{0}'!\n", getThreadName(), args...); };
+    // constexpr auto           func1  = []<typename... T>(T&&...args) { return fmt::format(fmt::format_string<std::string, T...>("thread '{1}' scheduled task '{0}'!\n"), getThreadName(), args...); };
+    constexpr auto           func1  = [](const auto &...args) { return fmt::format(fmt::runtime("thread '{1}' scheduled task '{0}'!\n"), getThreadName(), args...); };
     std::future<std::string> result = poolIO.execute<"customTaskName">(func1, getThreadName());
     // do something else ... get result, wait if necessary
     std::cout << result.get() << std::endl;

--- a/concepts/disruptor/QueueBenchmark.cpp
+++ b/concepts/disruptor/QueueBenchmark.cpp
@@ -177,8 +177,8 @@ double testDisruptor(const std::uint64_t nLoop, const std::uint64_t nProducer, c
     return opsPerSecond;
 }
 
-template<typename T, size_t mRow, size_t nCol>
-void print_matrix(const std::array<std::array<T, mRow>, nCol> &M, const char *fmt = "{}", const bool align = true) {
+template<bool align = true, typename T, size_t mRow, size_t nCol>
+void print_matrix(const std::array<std::array<T, mRow>, nCol> &M, fmt::format_string<const T &> fmt = "{}") {
     size_t columWidth = 0;
     for (size_t j = 0; j < nCol; ++j) {
         size_t max_len{};
@@ -192,8 +192,8 @@ void print_matrix(const std::array<std::array<T, mRow>, nCol> &M, const char *fm
     fmt::print("┌{1:{0}}┐\n", nCol * (columWidth + 1) + 1, ' ');
     for (size_t i = 0; i < mRow; ++i) {
         for (size_t j = 0; j < nCol; ++j) {
-            fmt::print(align ? "{1:}{2:>{0}} {3:}" : "{1:}{2:^{0}} {3:}",
-                    columWidth, j == 0 ? "│ " : "", fmt::format(fmt, M[i][j]), j == nCol - 1 ? "│" : "");
+            constexpr auto cell_fmt = align ? "{1:}{2:>{0}} {3:}" : "{1:}{2:^{0}} {3:}";
+            fmt::print(cell_fmt, columWidth, j == 0 ? "│ " : "", fmt::format(fmt, M[i][j]), j == nCol - 1 ? "│" : "");
         }
         fmt::print("\n");
     }

--- a/src/core/include/MIME.hpp
+++ b/src/core/include/MIME.hpp
@@ -261,7 +261,7 @@ struct fmt::formatter<opencmw::MIME::MimeType> {
     }
 
     template<typename FormatContext>
-    auto format(opencmw::MIME::MimeType const &v, FormatContext &ctx) {
+    auto format(opencmw::MIME::MimeType const &v, FormatContext &ctx) const {
         return fmt::format_to(ctx.out(), "{}", v.typeName());
     }
 };

--- a/src/core/include/ThreadAffinity.hpp
+++ b/src/core/include/ThreadAffinity.hpp
@@ -211,7 +211,7 @@ inline std::vector<bool> getProcessAffinity(const int pid = detail::getPid()) {
     }
     cpu_set_t cpuSet;
     if (int rc = sched_getaffinity(pid, sizeof(cpu_set_t), &cpuSet); rc != 0) {
-        throw std::system_error(rc, thread_exception(), fmt::format("getProcessAffinity(std::bitset<{}> = {}, thread_type)"));
+        throw std::system_error(rc, thread_exception(), fmt::format("getProcessAffinity(std::bitset<{{}}> = {{}}, thread_type)")); // todo: fix format string
     }
     return detail::getAffinityMask(cpuSet);
 #else

--- a/src/core/include/TimingCtx.hpp
+++ b/src/core/include/TimingCtx.hpp
@@ -207,10 +207,6 @@ inline static const TimingCtx NullTimingCtx = TimingCtx{};
 
 [[nodiscard]] inline bool     operator==(const TimingCtx &lhs, const std::string_view &rhs) { return (lhs.bpcts == 0) && (lhs.selector.value() == rhs); }
 
-inline std::ostream          &operator<<(std::ostream &os, const opencmw::TimingCtx &v) {
-    return os << fmt::format("{}", v);
-}
-
 } // namespace opencmw
 ENABLE_REFLECTION_FOR(opencmw::TimingCtx, selector, bpcts);
 
@@ -236,4 +232,9 @@ struct fmt::formatter<opencmw::TimingCtx> {
     }
 };
 
+namespace opencmw {
+inline std::ostream &operator<<(std::ostream &os, const opencmw::TimingCtx &v) {
+    return os << fmt::format("{}", v);
+}
+} // namespace opencmw
 #endif

--- a/src/core/include/TimingCtx.hpp
+++ b/src/core/include/TimingCtx.hpp
@@ -231,7 +231,7 @@ struct fmt::formatter<opencmw::TimingCtx> {
     }
 
     template<typename FormatContext>
-    auto format(const opencmw::TimingCtx &v, FormatContext &ctx) {
+    auto format(const opencmw::TimingCtx &v, FormatContext &ctx) const {
         return fmt::format_to(ctx.out(), "{}", v.toString());
     }
 };

--- a/src/core/include/URI.hpp
+++ b/src/core/include/URI.hpp
@@ -8,6 +8,7 @@
 #include <sstream>
 #include <string>
 #include <string_view>
+#include <unordered_map>
 
 #include <cassert>
 

--- a/src/core/include/URI.hpp
+++ b/src/core/include/URI.hpp
@@ -443,7 +443,7 @@ struct fmt::formatter<std::optional<T>> {
     }
 
     template<typename FormatContext>
-    auto format(std::optional<T> const &v, FormatContext &ctx) {
+    auto format(std::optional<T> const &v, FormatContext &ctx) const {
         return v ? fmt::format_to(ctx.out(), "{}", v.value()) : fmt::format_to(ctx.out(), "<std::nullopt>");
     }
 };
@@ -461,7 +461,7 @@ struct fmt::formatter<opencmw::URI<check>> {
     }
 
     template<typename FormatContext>
-    auto format(opencmw::URI<check> const &v, FormatContext &ctx) {
+    auto format(opencmw::URI<check> const &v, FormatContext &ctx) const {
         return fmt::format_to(ctx.out(), "{{scheme: '{}', authority: '{}', user: '{}', pwd: '{}', host: '{}', port: '{}', path: '{}', query: '{}', fragment: '{}'}}", //
                 v.scheme(), v.authority(), v.user(), v.password(), v.hostName(), v.port(), v.path(), v.queryParam(), v.fragment());
     }

--- a/src/core/include/opencmw.hpp
+++ b/src/core/include/opencmw.hpp
@@ -305,7 +305,7 @@ struct fmt::formatter<opencmw::ExternalModifier> {
     template<typename ParseContext>
     constexpr auto parse(ParseContext &ctx) { return ctx.begin(); }
     template<typename FormatContext>
-    constexpr auto format(const opencmw::ExternalModifier &state, FormatContext &ctx) {
+    constexpr auto format(const opencmw::ExternalModifier &state, FormatContext &ctx) const {
         using namespace opencmw;
         switch (state) {
         case RW: return fmt::format_to(ctx.out(), "RW");
@@ -749,7 +749,7 @@ struct fmt::formatter<T> {
     }
 
     template<typename FormatContext>
-    auto format(T const &value, FormatContext &ctx) {
+    auto format(T const &value, FormatContext &ctx) const {
         using namespace opencmw; // for operator<< overloading
         std::stringstream ss;    // N.B. std::stringstream construct to avoid recursion with 'operator<<' definition
         ss << value << std::flush;

--- a/src/serialiser/include/IoSerialiser.hpp
+++ b/src/serialiser/include/IoSerialiser.hpp
@@ -443,5 +443,29 @@ inline std::ostream &operator<<(std::ostream &os, const DeserialiserInfo &info) 
 
 } // namespace opencmw
 
+template<>
+struct fmt::formatter<opencmw::ProtocolCheck> {
+    template<typename ParseContext>
+    constexpr auto parse(ParseContext &ctx) {
+        return ctx.begin(); // not (yet) implemented
+    }
+
+    template<typename FormatContext>
+    auto format(opencmw::ProtocolCheck const &v, FormatContext &ctx) const {
+        switch (v) {
+        case opencmw::ProtocolCheck::IGNORE:
+            break;
+            return fmt::format_to(ctx.out(), "IGNORE");
+        case opencmw::ProtocolCheck::LENIENT:
+            break;
+            return fmt::format_to(ctx.out(), "LENIENT");
+        case opencmw::ProtocolCheck::ALWAYS:
+            break;
+            return fmt::format_to(ctx.out(), "ALWAYS");
+        default:
+            return ctx.out();
+        }
+    }
+};
 #pragma clang diagnostic pop
 #endif // OPENCMW_IOSERIALISER_H

--- a/src/serialiser/include/IoSerialiserJson.hpp
+++ b/src/serialiser/include/IoSerialiserJson.hpp
@@ -353,7 +353,7 @@ struct IoSerialiser<Json, T> {
             result = std::to_chars(data + start, data + size, value);
         }
         if (result.ec != std::errc()) {
-            throw ProtocolException("error({}) serialising number at buffer position: {}", result.ec, start);
+            throw ProtocolException("error({}) serialising number at buffer position: {}", static_cast<int>(result.ec), start);
         }
         buffer.resize(static_cast<size_t>(result.ptr - data)); // new position
     }
@@ -373,7 +373,7 @@ struct IoSerialiser<Json, T> {
         if constexpr (std::is_floating_point_v<T>) {
             const auto result = fast_float::from_chars(data + start, data + stop, value);
             if (result.ec != std::errc()) {
-                throw ProtocolException("error({}) parsing number at buffer position: {}", result.ec, start);
+                throw ProtocolException("error({}) parsing number at buffer position: {}", static_cast<int>(result.ec), start);
             }
             buffer.set_position(static_cast<size_t>(result.ptr - data)); // new position
             return;
@@ -381,7 +381,7 @@ struct IoSerialiser<Json, T> {
         // fall-back
         const auto result = std::from_chars(data + start, data + stop, value);
         if (result.ec != std::errc()) {
-            throw ProtocolException("error({}) parsing number at buffer position: {}", result.ec, start);
+            throw ProtocolException("error({}) parsing number at buffer position: {}", static_cast<int>(result.ec), start);
         }
         buffer.set_position(static_cast<size_t>(result.ptr - data)); // new position
     }

--- a/src/serialiser/test/Utils_tests.cpp
+++ b/src/serialiser/test/Utils_tests.cpp
@@ -197,13 +197,13 @@ TEST_CASE("Annotated stdout", "[Utils]") {
         std::ostringstream                        os;
         Annotated<std::array<double, 10>, NoUnit> annDoubleArray = std::array<double, 10>{ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
         os << ClassInfoVerbose << annDoubleArray;
-        REQUIRE(os.str() == "{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}  // [] - ");
+        REQUIRE(os.str() == "[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]  // [] - ");
     }
     {
         std::ostringstream                    os;
         Annotated<std::vector<float>, NoUnit> annFloatVector = std::vector{ 0.1f, 1.1f, 2.1f, 3.1f, 4.1f, 5.1f, 6.1f, 8.1f, 9.1f, 9.1f };
         os << ClassInfoVerbose << annFloatVector;
-        REQUIRE(os.str() == "{0.1, 1.1, 2.1, 3.1, 4.1, 5.1, 6.1, 8.1, 9.1, 9.1}  // [] - ");
+        REQUIRE(os.str() == "[0.1, 1.1, 2.1, 3.1, 4.1, 5.1, 6.1, 8.1, 9.1, 9.1]  // [] - ");
     }
     REQUIRE(opencmw::debug::dealloc == opencmw::debug::alloc); // a memory leak occurred
     debug::resetStats();


### PR DESCRIPTION
upgrades libfmt to 8.1.1

open questions:
- should we go directly to v9?
- formatter instead of static casts for std::errc?
- use of fmt::runtime in ThreadPool sample

see comments in the individual commits for more details