### PR TITLE
fixed JSON formatter

### DIFF
--- a/src/majordomo/test/majordomoworker_tests.cpp
+++ b/src/majordomo/test/majordomoworker_tests.cpp
@@ -173,7 +173,7 @@ TEST_CASE("Simple MajordomoWorker example showing its usage", "[majordomo][major
         REQUIRE(reply->clientRequestId() == "1");
         REQUIRE(reply->error() == "");
         REQUIRE(reply->topic() == "/addresses?contentType=application%2Fjson&ctx=FAIR.SELECTOR.ALL");
-        REQUIRE(reply->body() == "\"AddressEntry\": {\n\"name\": \"Santa Claus\",\n\"street\": \"Elf Road\",\n\"streetNumber\": 123,\n\"postalCode\": \"88888\",\n\"city\": \"North Pole\"\n}");
+        REQUIRE(reply->body() == "{\n\"name\": \"Santa Claus\",\n\"street\": \"Elf Road\",\n\"streetNumber\": 123,\n\"postalCode\": \"88888\",\n\"city\": \"North Pole\"\n}");
     }
 }
 
@@ -214,7 +214,7 @@ TEST_CASE("MajordomoWorker test using raw messages", "[majordomo][majordomoworke
         REQUIRE(reply->clientRequestId() == "1");
         REQUIRE(reply->error() == "");
         REQUIRE(reply->topic() == "/addresses?contentType=application%2Fjson&ctx=FAIR.SELECTOR.ALL");
-        REQUIRE(reply->body() == "\"AddressEntry\": {\n\"name\": \"Santa Claus\",\n\"street\": \"Elf Road\",\n\"streetNumber\": 123,\n\"postalCode\": \"88888\",\n\"city\": \"North Pole\"\n}");
+        REQUIRE(reply->body() == "{\n\"name\": \"Santa Claus\",\n\"street\": \"Elf Road\",\n\"streetNumber\": 123,\n\"postalCode\": \"88888\",\n\"city\": \"North Pole\"\n}");
     }
 
     // GET with unknown role or empty role fails
@@ -336,6 +336,6 @@ TEST_CASE("MajordomoWorker test using raw messages", "[majordomo][majordomoworke
         REQUIRE(notify->sourceId() == "/newAddress?ctx=FAIR.SELECTOR.C=1");
         REQUIRE(notify->topic() == "/newAddress?contentType=application%2Fjson&ctx=FAIR.SELECTOR.C%3D1");
         REQUIRE(notify->error().empty());
-        REQUIRE(notify->body() == "\"AddressEntry\": {\n\"name\": \"Easter Bunny\",\n\"street\": \"Carrot Road\",\n\"streetNumber\": 123,\n\"postalCode\": \"88888\",\n\"city\": \"Easter Island\"\n}");
+        REQUIRE(notify->body() == "{\n\"name\": \"Easter Bunny\",\n\"street\": \"Carrot Road\",\n\"streetNumber\": 123,\n\"postalCode\": \"88888\",\n\"city\": \"Easter Island\"\n}");
     }
 }

--- a/src/serialiser/include/IoSerialiserJson.hpp
+++ b/src/serialiser/include/IoSerialiserJson.hpp
@@ -232,7 +232,7 @@ struct FieldHeaderWriter<Json> {
         using namespace std::string_view_literals;
         constexpr auto WITHOUT = opencmw::IoBuffer::MetaInfo::WITHOUT;
         if constexpr (std::is_same_v<DataType, START_MARKER>) {
-            if (field.fieldName.size() > 0) {
+            if (field.fieldName.size() > 0 && field.hierarchyDepth > 0) {
                 buffer.put<WITHOUT>("\""sv);
                 buffer.put<WITHOUT>(field.fieldName);
                 buffer.put<WITHOUT>("\": "sv);

--- a/src/serialiser/test/IoSerialiserJson_tests.cpp
+++ b/src/serialiser/test/IoSerialiserJson_tests.cpp
@@ -70,7 +70,7 @@ TEST_CASE("JsonSerialiserRegressions", "[JsonSerialiser]") {
     opencmw::IoBuffer buffer;
     auto              foo = ReproduceMissingCommaAfterNestedObject{ SimpleInner{ 2.3, "test", { 4, 2 } }, "bar", "baz" };
     opencmw::serialise<opencmw::Json>(buffer, foo);
-    auto expected = R"""("opencmw::ioserialiser_json_tests::ReproduceMissingCommaAfterNestedObject": {
+    auto expected = R"""({
 "a": {
 "val1": 2.3e+00,
 "val2": "test",


### PR DESCRIPTION
... to not emit a leading map name for the outer scope.

was: '"<root>": { /*[..]*/ }'
now: '{ /*[..]*/ }'

produces JSON compatible with https://jsonlint.com/ et. al.