### PR TITLE
IoSerialiser: add support for std::set

### DIFF
--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -9,7 +9,7 @@ on:
     types: [ created ]
 
 env:
-  REFERENCE_CONFIG: 'Ubuntu Latest gcc' # configuration used for coverage etc
+  REFERENCE_CONFIG: 'Ubuntu Latest gcc12' # configuration used for coverage etc
 
 jobs:
   build:
@@ -20,20 +20,20 @@ jobs:
       fail-fast: false
       matrix:
         configurations:
-          - name: Ubuntu Latest gcc
-            os: ubuntu-22.04 # pre-release, ubuntu-latest still points to ubuntu-2004
+          - name: Ubuntu Latest gcc12
+            os: ubuntu-22.04
             compiler: gcc
-          - name: Ubuntu Latest clang
-            os: ubuntu-22.04 # pre-release, ubuntu-latest still points to ubuntu-2004
-            compiler: clang
-          - name: Ubuntu Latest clang15
-            os: ubuntu-22.04 # pre-release, ubuntu-latest still points to ubuntu-2004
+          - name: Ubuntu Latest clang14
+            os: ubuntu-22.04
+            compiler: clang14
+          - name: ubuntu-22.04 clang15
+            os: ubuntu-22.04
             compiler: clang15
-          - name: Ubuntu Latest clang16
-            os: ubuntu-22.04 # pre-release, ubuntu-latest still points to ubuntu-2004
+          - name: ubuntu Latest clang16
+            os: ubuntu-22.04
             compiler: clang16
-          - name: Ubuntu Latest emscripten
-            os: ubuntu-22.04 # pre-release, ubuntu-latest still points to ubuntu-2004
+          - name: ubuntu-22.04 emscripten
+            os: ubuntu-22.04
             compiler: emscripten
           # - name: MacOS Latest # deactivated because mp-units is not compatible with clangApple
           #   os: macos-latest
@@ -58,11 +58,12 @@ jobs:
     - name: Install gcc-12
       if: matrix.configurations.compiler == 'gcc'
       run: |
+        sudo add-apt-repository ppa:ubuntu-toolchain-r/ppa # provides newer gcc 12.2.0 instead of 12.1.0
         sudo apt-get install -y gcc-12 g++-12
         sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-12 110 --slave /usr/bin/g++ g++ /usr/bin/g++-12 --slave /usr/bin/gcov gcov /usr/bin/gcov-12
 
     - name: Install clang-14
-      if: matrix.configurations.compiler == 'clang'
+      if: matrix.configurations.compiler == 'clang14'
       run: |
         wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add -
         sudo add-apt-repository 'deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-14 main'

--- a/docs/CompileTimeSerialiser.md
+++ b/docs/CompileTimeSerialiser.md
@@ -25,7 +25,7 @@ Field names that are not listed are implicitly considered `private` and not take
 The following types and (nested) class structures are supported:
 Beside common primitive and STL container types, 
  * primitives `T`: `uint8_t` `int8_t`, `int16_t`, `int32_t`, `int64_t`, `float`, `double`, `std::string` and `std::string_view`
- * stl-container: `std::array<T,N>`, `std::vector<T,N>`, `std::list<T>`, `std::unsorted_map<T>`, `std::queue<T>`, `std::set<T>`
+ * stl-container: `std::array<T,N>`, `std::vector<T,N>`, `std::list<T>`, `std::unsorted_map<T>`, `std::set<T>` (not yet implemented: `std::queue<T>`)
  * common opencmw container: `opencmw:MultiArray<T, N_DIM>`
 
 N.B. regarding support/extensions for `unsigned` arithmetic types see [here](###-unsigned-data-types). Based on this reflection pattern, there are some

--- a/src/core/include/opencmw.hpp
+++ b/src/core/include/opencmw.hpp
@@ -599,7 +599,7 @@ inline std::ostream &operator<<(std::ostream &os, const T &v) {
 template<typename Rep, units::Quantity Q, const basic_fixed_string description, const ExternalModifier modifier, const basic_fixed_string... groups>
 inline std::ostream &operator<<(std::ostream &os, const Annotated<Rep, Q, description, modifier, groups...> &annotatedValue) {
     if (os.iword(getClassInfoVerbose())) {
-        if constexpr (!is_array<Rep> && !is_vector<Rep>) {
+        if constexpr (!is_array<Rep> && !is_vector<Rep> && !units::is_derived_from_specialization_of<Rep, std::set>) {
             os << fmt::format("{:<5}  // [{}] - {}", annotatedValue.value(), annotatedValue.getUnit(), annotatedValue.getDescription()); // print as number
         } else {
             os << fmt::format("{}  // [{}] - {}", annotatedValue.value(), annotatedValue.getUnit(), annotatedValue.getDescription()); // print as array
@@ -641,6 +641,12 @@ inline std::ostream &operator<<(std::ostream &os, const T &map) {
         os << key << ':' << val;
     }
     os << "}";
+    return os;
+}
+
+template<typename T>
+inline std::ostream &operator<<(std::ostream &os, const std::set<T> &set) {
+    os << fmt::format("{{{}}}", fmt::join(set, ", "));
     return os;
 }
 

--- a/src/serialiser/include/IoBuffer.hpp
+++ b/src/serialiser/include/IoBuffer.hpp
@@ -422,7 +422,7 @@ public:
     }
 
     template<SupportedType R>
-    forceinline constexpr std::vector<R> &getArray(std::vector<R> &&input = std::vector<R>(), const std::size_t &requestedSize = SIZE_MAX) noexcept { return getArray<R>(input, requestedSize); }
+    forceinline constexpr std::vector<R> getArray(std::vector<R> &&input = std::vector<R>(), const std::size_t &requestedSize = SIZE_MAX) noexcept { return getArray<R>(input, requestedSize); }
 
     template<SupportedType R, std::size_t size>
     forceinline constexpr std::array<R, size> &getArray(std::array<R, size> &input, const std::size_t &requestedSize = SIZE_MAX) noexcept {
@@ -441,16 +441,16 @@ public:
     }
 
     template<SupportedType R, std::size_t size>
-    [[maybe_unused]] forceinline constexpr std::array<R, size> &getArray(std::array<R, size> &&input = std::array<R, size>(), const std::size_t &requestedSize = size) noexcept { return getArray<R, size>(input, requestedSize); }
+    [[maybe_unused]] forceinline constexpr std::array<R, size> getArray(std::array<R, size> &&input = std::array<R, size>(), const std::size_t &requestedSize = size) noexcept { return getArray<R, size>(input, requestedSize); }
 
     template<StringArray R, typename T = typename R::value_type>
     [[nodiscard]] forceinline constexpr R &get(R &input, const std::size_t &requestedSize = SIZE_MAX) noexcept { return getArray<T>(input, requestedSize); }
     template<StringArray R, typename T = typename R::value_type>
-    [[nodiscard]] forceinline constexpr R &get(R &&input = R(), const std::size_t &requestedSize = SIZE_MAX) noexcept { return getArray<T>(input, requestedSize); }
+    [[nodiscard]] forceinline constexpr R get(R &&input = R(), const std::size_t &requestedSize = SIZE_MAX) noexcept { return getArray<T>(input, requestedSize); }
     template<StringArray R, typename T = typename R::value_type, std::size_t size>
     [[nodiscard]] forceinline constexpr R &get(R &input, const std::size_t &requestedSize = size) noexcept { return getArray<T, size>(input, requestedSize); }
     template<StringArray R, typename T = typename R::value_type, std::size_t size>
-    [[nodiscard]] forceinline constexpr R &get(R &&input = R(), const std::size_t &requestedSize = size) noexcept { return getArray<T, size>(input, requestedSize); }
+    [[nodiscard]] forceinline constexpr R get(R &&input = R(), const std::size_t &requestedSize = size) noexcept { return getArray<T, size>(input, requestedSize); }
 };
 
 } // namespace opencmw

--- a/src/serialiser/include/IoSerialiserYaS.hpp
+++ b/src/serialiser/include/IoSerialiserYaS.hpp
@@ -158,7 +158,7 @@ struct IoSerialiser<YaS, T> {
             }
         } else {                                     // non-primitive or non-string-like types
             buffer.put(yas::getDataTypeId<OTHER>()); // type-id
-            buffer.put(typeName<K>());               // primary type
+            buffer.put(typeName<K>);                 // primary type
             buffer.put("");                          // secondary type (if any) TODO: add appropriate
             buffer.put(nElements);
             for (auto &entry : value) {
@@ -176,11 +176,11 @@ struct IoSerialiser<YaS, T> {
             }
         } else {                                         // non-primitive or non-string-like types
             buffer.put(yas::getDataTypeId<OTHER>());     // type-id
-            buffer.put(typeName<V>());                   // primary type
+            buffer.put(typeName<V>);                     // primary type
             buffer.put("");                              // secondary type (if any) TODO: add appropriate
             buffer.put(static_cast<int32_t>(nElements)); // nElements
             for (auto &entry : value) {
-                IoSerialiser<YaS, K>::serialise(buffer, field, entry.second);
+                IoSerialiser<YaS, V>::serialise(buffer, field, entry.second);
             }
         }
     }
@@ -211,7 +211,7 @@ struct IoSerialiser<YaS, T> {
 
         const auto valueType = buffer.get<uint8_t>();
         if constexpr (is_supported_number<V> || is_stringlike<V>) {
-            if (yas::getDataTypeId<K>() != keyType) {
+            if (yas::getDataTypeId<V>() != valueType) {
                 throw ProtocolException("value type mismatch for field {} - required {} ({}) vs. have {}", field.fieldName, yas::getDataTypeId<V>(), typeid(V).name(), valueType);
             }
             const auto nElementsCheck = static_cast<uint32_t>(buffer.get<int32_t>());
@@ -223,8 +223,24 @@ struct IoSerialiser<YaS, T> {
                 auto v         = buffer.get<V>();
                 value[keys[i]] = v;
             }
-        } else if (keyType == yas::getDataTypeId<OTHER>()) {
-            throw ProtocolException("value type OTHER for field {} not yet implemented", field.fieldName);
+        } else if (valueType == yas::getDataTypeId<OTHER>()) {
+            std::string value_type_name           = buffer.get<std::string>();
+            std::string value_type_name_secondary = buffer.get<std::string>();
+            auto        value_elements            = static_cast<std::size_t>(buffer.get<int32_t>());
+            for (std::size_t i = 0; i < value_elements; i++) {
+                FieldDescriptionShort subfield{
+                    .headerStart       = buffer.position(),
+                    .dataStartPosition = buffer.position(),
+                    .dataEndPosition   = 0U,
+                    .subfields         = 0,
+                    .fieldName         = fmt::format("{}[{}]", field.fieldName, i),
+                    .intDataType       = IoSerialiser<YaS, V>::getDataTypeId(),
+                    .hierarchyDepth    = static_cast<uint8_t>(field.hierarchyDepth + 1),
+                };
+                V v;
+                IoSerialiser<YaS, V>::deserialise(buffer, subfield, v);
+                value[keys[i]] = v;
+            }
         } else {
             throw ProtocolException("unsupported key type {} for field {}", keyType, field.fieldName);
         }

--- a/src/serialiser/include/IoSerialiserYaS.hpp
+++ b/src/serialiser/include/IoSerialiserYaS.hpp
@@ -146,8 +146,7 @@ struct IoSerialiser<YaS, T> {
         using K              = typename T::key_type;
         using V              = typename T::mapped_type;
         const auto nElements = static_cast<int32_t>(value.size());
-        buffer.put(std::array<int32_t, 1>{ nElements }); // [ndims]{size}
-        buffer.put(nElements);                           // nElements
+        buffer.put(nElements); // nElements
 
         if constexpr (is_supported_number<K> || is_stringlike<K>) {
             constexpr int entrySize = 17; // as an initial estimate
@@ -188,7 +187,6 @@ struct IoSerialiser<YaS, T> {
     static void deserialise(IoBuffer &buffer, FieldDescription auto const &field, T &value) {
         using K                  = typename T::key_type;
         using V                  = typename T::mapped_type;
-        const auto     dimWire   = buffer.getArray<int32_t>(); // [ndims]{size}
         const auto     nElements = static_cast<uint32_t>(buffer.get<int32_t>());
 
         const auto     keyType   = buffer.get<uint8_t>();

--- a/src/serialiser/include/MustacheSerialiser.hpp
+++ b/src/serialiser/include/MustacheSerialiser.hpp
@@ -189,6 +189,33 @@ public:
     }
 };
 
+template<typename MemberType>
+class mustache_data<std::set<MemberType>> : public mustache_data_base {
+private:
+    const std::set<MemberType> &_value;
+
+    // Allowing single iteration over the list
+    mutable typename std::set<MemberType>::const_iterator _it;
+    mutable std::unique_ptr<mustache_data_base>           _current;
+
+public:
+    explicit mustache_data(const std::set<MemberType> &value)
+        : mustache_data_base(value.empty() ? type::list_empty : type::list_non_empty)
+        , _value(std::move(value))
+        , _it(_value.cbegin()) {}
+
+    const mustache_data_base *next_list_item() const override {
+        _current.reset();
+
+        if (_it == _value.cend()) return nullptr;
+
+        _current = std::make_unique<mustache_data<MemberType>>(*_it);
+        ++_it;
+
+        return _current.get();
+    }
+};
+
 template<MultiArrayType T>
 class mustache_data<T> : public mustache_data<std::vector<typename T::value_type>> {
 public:

--- a/src/serialiser/test/IoSerialiserCmwLight_tests.cpp
+++ b/src/serialiser/test/IoSerialiserCmwLight_tests.cpp
@@ -30,12 +30,13 @@ struct SimpleTestData {
     std::vector<std::string>        ce{ "hello", "world" };
     opencmw::MultiArray<double, 2>  d{ { 1, 2, 3, 4, 5, 6 }, { 2, 3 } };
     std::unique_ptr<SimpleTestData> e = nullptr;
+    std::set<std::string>           f{ "one", "two", "three" };
     bool                            operator==(const ioserialiser_cmwlight_test::SimpleTestData &other) const { // deep comparison function
-        return a == other.a && ab == other.ab && abc == other.abc && b == other.b && c == other.c && cd == other.cd && d == other.d && ((!e && !other.e) || *e == *(other.e));
+        return a == other.a && ab == other.ab && abc == other.abc && b == other.b && c == other.c && cd == other.cd && d == other.d && ((!e && !other.e) || *e == *(other.e)) && f == other.f;
     }
 };
 } // namespace ioserialiser_cmwlight_test
-ENABLE_REFLECTION_FOR(ioserialiser_cmwlight_test::SimpleTestData, a, ab, abc, b, c, cd, ce, d, e)
+ENABLE_REFLECTION_FOR(ioserialiser_cmwlight_test::SimpleTestData, a, ab, abc, b, c, cd, ce, d, e, f)
 
 TEST_CASE("IoClassSerialiserCmwLight simple test", "[IoClassSerialiser]") {
     using namespace opencmw;
@@ -65,7 +66,8 @@ TEST_CASE("IoClassSerialiserCmwLight simple test", "[IoClassSerialiser]") {
                       .cd  = { 3.1, 1.2 },
                       .ce  = { "ei", "gude" },
                       .d   = { { 6, 5, 4, 3, 2, 1 }, { 3, 2 } },
-                      .e   = nullptr })
+                      .e   = nullptr }),
+            .f   = { "four", "five" }
         };
 
         // check that empty buffer cannot be deserialised
@@ -115,9 +117,10 @@ struct SimpleTestDataMoreFields {
     opencmw::MultiArray<double, 2>  d{ { 1, 2, 3, 4, 5, 6 }, { 2, 3 } };
     bool                            operator==(const SimpleTestDataMoreFields &) const = default;
     std::unique_ptr<SimpleTestData> e                                                  = nullptr;
+    std::set<std::string>           f{ "one", "two", "three" };
 };
 } // namespace ioserialiser_cmwlight_test
-ENABLE_REFLECTION_FOR(ioserialiser_cmwlight_test::SimpleTestDataMoreFields, a2, ab2, abc2, b2, c2, cd2, ce2, d2, e2, a, ab, abc, b, c, cd, ce, d, e)
+ENABLE_REFLECTION_FOR(ioserialiser_cmwlight_test::SimpleTestDataMoreFields, a2, ab2, abc2, b2, c2, cd2, ce2, d2, e2, a, ab, abc, b, c, cd, ce, d, e, f)
 
 #pragma clang diagnostic pop
 TEST_CASE("IoClassSerialiserCmwLight missing field", "[IoClassSerialiser]") {
@@ -138,7 +141,8 @@ TEST_CASE("IoClassSerialiserCmwLight missing field", "[IoClassSerialiser]") {
             .c   = { 5, 4, 3 },
             .cd  = { 2.1, 4.2 },
             .ce  = { "hallo", "welt" },
-            .d   = { { 6, 5, 4, 3, 2, 1 }, { 3, 2 } }
+            .d   = { { 6, 5, 4, 3, 2, 1 }, { 3, 2 } },
+            .f   = { "four", "six" }
         };
         SimpleTestDataMoreFields data2;
         std::cout << fmt::format("object (fmt): {}\n", data);
@@ -147,7 +151,7 @@ TEST_CASE("IoClassSerialiserCmwLight missing field", "[IoClassSerialiser]") {
         auto result = opencmw::deserialise<opencmw::CmwLight, ProtocolCheck::LENIENT>(buffer, data2);
         std::cout << fmt::format("deserialised object (fmt): {}\n", data2);
         std::cout << "deserialisation messages: " << result << std::endl;
-        REQUIRE(result.setFields["root"] == std::vector<bool>{ 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 0 });
+        REQUIRE(result.setFields["root"] == std::vector<bool>{ 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1 });
         REQUIRE(result.additionalFields.empty());
         REQUIRE(result.exceptions.empty());
 
@@ -158,7 +162,7 @@ TEST_CASE("IoClassSerialiserCmwLight missing field", "[IoClassSerialiser]") {
         auto result_back = opencmw::deserialise<opencmw::CmwLight, ProtocolCheck::LENIENT>(buffer, data);
         std::cout << fmt::format("deserialised object (fmt): {}\n", data);
         std::cout << "deserialisation messages: " << result_back << std::endl;
-        REQUIRE(result_back.setFields["root"] == std::vector<bool>{ 1, 1, 1, 1, 1, 1, 1, 1, 0 });
+        REQUIRE(result_back.setFields["root"] == std::vector<bool>{ 1, 1, 1, 1, 1, 1, 1, 1, 0, 1 });
         REQUIRE(result_back.additionalFields.size() == 8);
         REQUIRE(result_back.exceptions.size() == 8);
     }

--- a/src/serialiser/test/IoSerialiserJson_tests.cpp
+++ b/src/serialiser/test/IoSerialiserJson_tests.cpp
@@ -34,14 +34,15 @@ struct DataX {
     std::vector<float>             floatVector = { 0.1F, 1.1F, 2.1F, 3.1F, 4.1F, 5.1F, 6.1F, 8.1F, 9.1F, 9.1F };
     opencmw::MultiArray<double, 2> doubleMatrix{ { 1, 3, 7, 4, 2, 3 }, { 2, 3 } };
     std::map<std::string, double>  doubleMap{ std::pair<std::string, double>{ "hello", 42.23 }, std::pair<std::string, double>{ "map", 1.337 } };
+    std::set<std::string>          stringSet{ "foo", "bar", "baz" };
     std::shared_ptr<DataX>         nested;
 
     DataX() = default;
     bool operator==(const DataX &other) const { // deep comparison function
-        return boolValue == other.boolValue && byteValue == other.byteValue && shortValue == other.shortValue && intValue == other.intValue && longValue == other.longValue && floatValue == other.floatValue && doubleValue == other.doubleValue && stringValue == other.stringValue && doubleArray == other.doubleArray && floatVector == other.floatVector && doubleMatrix == other.doubleMatrix && ((!nested && !other.nested) || *nested == *(other.nested));
+        return boolValue == other.boolValue && byteValue == other.byteValue && shortValue == other.shortValue && intValue == other.intValue && longValue == other.longValue && floatValue == other.floatValue && doubleValue == other.doubleValue && stringValue == other.stringValue && doubleArray == other.doubleArray && floatVector == other.floatVector && doubleMatrix == other.doubleMatrix && stringSet == other.stringSet && ((!nested && !other.nested) || *nested == *(other.nested));
     }
 };
-ENABLE_REFLECTION_FOR(DataX, boolValue, byteValue, shortValue, intValue, longValue, floatValue, doubleValue, stringValue, doubleArray, floatVector, doubleMatrix, doubleMap, nested)
+ENABLE_REFLECTION_FOR(DataX, boolValue, byteValue, shortValue, intValue, longValue, floatValue, doubleValue, stringValue, doubleArray, floatVector, doubleMatrix, doubleMap, stringSet, nested)
 
 struct SimpleInner {
     double           val1;

--- a/src/serialiser/test/IoSerialiserYAML_tests.cpp
+++ b/src/serialiser/test/IoSerialiserYAML_tests.cpp
@@ -1,6 +1,5 @@
 #include <catch2/catch.hpp>
 
-#include <algorithm>
 #include <iostream>
 #include <string_view>
 
@@ -65,16 +64,17 @@ struct DataY {
     std::vector<float>                              floatVector      = { 0.1F, 1.1F, 2.1F, 3.1F, 4.1F, 5.1F, 6.1F, 8.1F, 9.1F, 9.1F };
     opencmw::MultiArray<double, 2>                  doubleMatrix{ { 1, 3, 7, 4, 2, 3 }, { 2, 3 } };
     NestedDataY                                     nestedData;
-    Annotated<double, resistance<ohm>>              annotatedValue                  = 0.1;
+    Annotated<double, resistance<ohm>>              annotatedValue = 0.1;
 
-    std::map<std::string, std::string, std::less<>> map                             = { { "key1", "value1" }, { "key2", "value2" }, { "key3", "value3" }, { "key4", "value4" }, { "key5", "value5" }, { "key6", "value6" } };
-    std::map<std::string, std::string, std::less<>> smallMap                        = { { "key1", "value1" } };
+    std::map<std::string, std::string, std::less<>> map            = { { "key1", "value1" }, { "key2", "value2" }, { "key3", "value3" }, { "key4", "value4" }, { "key5", "value5" }, { "key6", "value6" } };
+    std::map<std::string, std::string, std::less<>> smallMap       = { { "key1", "value1" } };
+    std::set<std::string>                           stringSet{ "foo", "bar", "baz" };
 
     bool                                            operator==(const DataY &) const = default;
 };
 } // namespace io_serialiser_yaml_test
 // following is the visitor-pattern-macro that allows the compile-time reflections via refl-cpp
-ENABLE_REFLECTION_FOR(io_serialiser_yaml_test::DataY, boolValue, byteValue, shortValue, intValue, longValue, floatValue, doubleValue, stringValue, constStringValue, doubleArray, floatVector, /*doubleMatrix,*/ nestedData, annotatedValue, map, smallMap)
+ENABLE_REFLECTION_FOR(io_serialiser_yaml_test::DataY, boolValue, byteValue, shortValue, intValue, longValue, floatValue, doubleValue, stringValue, constStringValue, doubleArray, floatVector, /*doubleMatrix,*/ nestedData, annotatedValue, map, smallMap, stringSet)
 
 template<opencmw::SerialiserProtocol protocol, opencmw::ReflectableClass T>
 void checkSerialiserIdentity(opencmw::IoBuffer &buffer, const T &a, T &b) {
@@ -127,6 +127,7 @@ TEST_CASE("basic YAML serialisation", "[IoClassSerialiserYAML]") {
         data2.nestedData.annBoolArray[2] = false;
         data2.map["key7"]                = "value7";
         data2.smallMap.clear();
+        data2.stringSet.clear();
         REQUIRE(data != data2);
 
         opencmw::serialise<opencmw::YAML>(buffer, data);

--- a/src/serialiser/test/IoSerialiserYaS_tests.cpp
+++ b/src/serialiser/test/IoSerialiserYaS_tests.cpp
@@ -45,13 +45,14 @@ struct NestedData {
     Annotated<std::string, NoUnit, "custom description for string">            annStringValue = std::string("nested string");
     Annotated<std::array<double, 10>, NoUnit>                                  annDoubleArray = std::array<double, 10>{ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
     Annotated<std::vector<float>, NoUnit>                                      annFloatVector = std::vector{ 0.1f, 1.1f, 2.1f, 3.1f, 4.1f, 5.1f, 6.1f, 8.1f, 9.1f, 9.1f };
+    Annotated<std::set<int>, NoUnit, "Let's not forget about sets!">           annIntSet      = { 1, 2, 3, 5, 7, 11 };
 
     // some default operator
     auto operator<=>(const NestedData &) const = default;
     bool operator==(const NestedData &) const  = default;
 };
 // following is the visitor-pattern-macro that allows the compile-time reflections via refl-cpp
-ENABLE_REFLECTION_FOR(NestedData, annByteValue, annShortValue, annIntValue, annLongValue, annFloatValue, annDoubleValue, annStringValue, annDoubleArray, annFloatVector)
+ENABLE_REFLECTION_FOR(NestedData, annByteValue, annShortValue, annIntValue, annLongValue, annFloatValue, annDoubleValue, annStringValue, annDoubleArray, annFloatVector, annIntSet)
 
 struct Data {
     int8_t                             byteValue        = 1;
@@ -122,6 +123,7 @@ TEST_CASE("IoClassSerialiser basic syntax", "[IoClassSerialiser]") {
         data2.nestedData.annDoubleArray[3] = 99;
         data2.doubleMatrix(0U, 0U)         = 42;
         data2.nestedData.annFloatVector.clear();
+        data2.nestedData.annIntSet.clear();
         REQUIRE(data != data2);
 
         opencmw::serialise<opencmw::YaS>(buffer, data);
@@ -155,14 +157,15 @@ struct NestedDataWithDifferences {
     Annotated<std::string, NoUnit, "deprecation notice", RW_DEPRECATED>           annStringValue = std::string("nested string"); // <- extra deprecation specifier
     Annotated<std::array<double, 10>, NoUnit, "private field notice", RW_PRIVATE> annDoubleArray = std::array<double, 10>{ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
     // Annotated<std::vector<float>, NoUnit>                                                annFloatVector; // <- missing field
-    Annotated<std::string, NoUnit, "custom description for string"> annExtraValue = std::string("nested string"); // <- extra value
+    Annotated<std::set<int>, NoUnit, "Let's not forget about sets!"> annIntSet     = { 1, 2, 3, 5, 7, 11 };
+    Annotated<std::string, NoUnit, "custom description for string">  annExtraValue = std::string("nested string"); // <- extra value
 
     // some default operator
     auto operator<=>(const NestedDataWithDifferences &) const = default;
     bool operator==(const NestedDataWithDifferences &) const  = default;
 };
 // following is the visitor-pattern-macro that allows the compile-time reflections via refl-cpp
-ENABLE_REFLECTION_FOR(NestedDataWithDifferences, annByteValue, annShortValue, annIntValue, annLongValue, annFloatValue, annDoubleValue, annStringValue, annDoubleArray, annExtraValue)
+ENABLE_REFLECTION_FOR(NestedDataWithDifferences, annByteValue, annShortValue, annIntValue, annLongValue, annFloatValue, annDoubleValue, annStringValue, annDoubleArray, annIntSet, annExtraValue)
 
 TEST_CASE("IoClassSerialiser protocol mismatch", "[IoClassSerialiser]") {
     std::cout << std::unitbuf;
@@ -202,8 +205,8 @@ TEST_CASE("IoClassSerialiser protocol mismatch", "[IoClassSerialiser]") {
         REQUIRE(7 == info.exceptions.size());
         REQUIRE(1 == info.additionalFields.size());
         REQUIRE(1 == info.setFields.size());
-        REQUIRE(9 == (info.setFields["root"].size()));
-        REQUIRE(5 == std::count_if(info.setFields["root"].begin(), info.setFields["root"].end(), [](bool bit) { return bit == true; }));
+        REQUIRE(10 == (info.setFields["root"].size()));
+        REQUIRE(6 == std::count_if(info.setFields["root"].begin(), info.setFields["root"].end(), [](bool bit) { return bit == true; }));
     }
     REQUIRE(opencmw::debug::dealloc == opencmw::debug::alloc); // a memory leak occurred
     debug::resetStats();

--- a/src/serialiser/test/MustacheSerialiser_tests.cpp
+++ b/src/serialiser/test/MustacheSerialiser_tests.cpp
@@ -96,4 +96,19 @@ TEST_CASE("MustacheSerialization: value with fallback serialisation", "[Mustache
     }
 }
 
+struct MustacheDataWithSet {
+    std::set<std::string> strings;
+    std::set<float>       floats;
+};
+ENABLE_REFLECTION_FOR(MustacheDataWithSet, strings, floats)
+
+TEST_CASE("MustacheSerialization: value with set of strings and set of floats", "[Mustache][MustacheValueSerialiser]") {
+    std::stringstream   str;
+    MustacheDataWithSet data{ .strings = { "Set", "of", "Strings" }, .floats = { 1.337f, 4.2f, 2.3f } };
+    opencmw::mustache::serialise("", str, std::pair<std::string, const MustacheDataWithSet &>{ "result"s, data });
+
+    REQUIRE(str.str() == R"""([strings::["Set", "Strings", "of"]][floats::[1.337e+00, 2.3e+00, 4.2e+00]]
+)""");
+}
+
 #pragma clang diagnostic pop


### PR DESCRIPTION
This adds support for std::set to the IoSerialiser solving #252 

- [x] IoSerialiserYas
- [x] IoSerialiserJSON
- [x] IoSerialiserYAML
- [x] IoSerialiserJSON
- [x] MustacheSerialiser
- [x] IoSerialiserCmwLight

Also adds the following:

- [x] Fix dangerous function overloads returning references to local objects
- [x] Add more tests for nested containers (for now only YaS)
- [x] IoSerialiserYaS: Fix/Implement nested maps
- [x] Bump CI to gcc 12.2 and cleanup some comments and job names