### PR TITLE
More subscription+REST fixes

### DIFF
--- a/src/majordomo/include/majordomo/Broker.hpp
+++ b/src/majordomo/include/majordomo/Broker.hpp
@@ -524,6 +524,7 @@ private:
             it->second--;
             if (it->second == 0) {
                 zmq_invoke(zmq_setsockopt, _subSocket, ZMQ_UNSUBSCRIBE, topic.str().data(), topic.str().size()).assertSuccess();
+                _subscribedTopics.erase(it);
             }
         }
     }

--- a/src/majordomo/include/majordomo/Broker.hpp
+++ b/src/majordomo/include/majordomo/Broker.hpp
@@ -685,25 +685,24 @@ private:
     }
 
     void dispatchMessageToMatchingSubscribers(BrokerMessage &&message) {
-        const auto topicURI               = URI<RELAXED>(std::string(message.topic()));
-        const auto it                     = _subscribedClientsByTopic.find(topicURI);
-        const auto hasRouterSubscriptions = it != _subscribedClientsByTopic.end();
+        const auto topicURI = URI<RELAXED>(std::string(message.topic()));
 
         // TODO avoid clone() for last message sent out
-        for (const auto &[topic, clientId] : _subscribedTopics) {
+        for (const auto &[topic, _] : _subscribedTopics) {
             if (_subscriptionMatcher(topicURI, topic)) {
                 // sends notification with the topic that is expected by the client for its subscription
                 auto copy = message.clone();
                 copy.setSourceId(topic.str(), MessageFrame::dynamic_bytes_tag{});
                 copy.send(_pubSocket).assertSuccess();
-            }
-        }
 
-        if (hasRouterSubscriptions) {
-            for (const auto &clientId : it->second) {
-                auto copy = message.clone();
-                copy.setSourceId(clientId, MessageFrame::dynamic_bytes_tag{});
-                copy.send(_routerSocket).assertSuccess();
+                const auto it = _subscribedClientsByTopic.find(topic);
+                if (it != _subscribedClientsByTopic.end()) {
+                    for (const auto &clientId : it->second) {
+                        auto copy = message.clone();
+                        copy.setSourceId(clientId, MessageFrame::dynamic_bytes_tag{});
+                        copy.send(_routerSocket).assertSuccess();
+                    }
+                }
             }
         }
     }

--- a/src/majordomo/include/majordomo/RestBackend.hpp
+++ b/src/majordomo/include/majordomo/RestBackend.hpp
@@ -734,6 +734,9 @@ struct RestBackend<Mode, VirtualFS, Roles...>::RestWorker {
                            .path(request.path)
                            .addQueryParameter("LongPollingIdx", std::to_string(redirectLongPollingIdx));
 
+        // copy over the original query parameters
+        addParameters(request, uri);
+
         const auto redirect = uri.toString();
         response.set_redirect(redirect);
         return true;
@@ -741,9 +744,12 @@ struct RestBackend<Mode, VirtualFS, Roles...>::RestWorker {
 
     bool respondWithLongPoll(const httplib::Request &request, httplib::Response &response, const std::string_view &_service) {
         // TODO: After the URIs are formalized, rethink service and topic
-        auto                     split = std::ranges::find(_service, '/');
-        std::string              service(_service.begin(), split);
-        std::string              topic = "/"s + service + std::string(split, _service.end());
+        auto        split = std::ranges::find(_service, '/');
+        std::string service(_service);
+
+        auto        uri = URI<>::factory();
+        addParameters(request, uri);
+        std::string              topic = "/"s + service + uri.toString();
 
         detail::SubscriptionInfo subscriptionInfo{ service, topic };
 
@@ -846,6 +852,18 @@ struct RestBackend<Mode, VirtualFS, Roles...>::RestWorker {
 
         } else {
             return detail::respondWithError(response, "Error: We waited for the new value, but it was not found");
+        }
+    }
+
+private:
+    void addParameters(const httplib::Request &request, URI<>::UriFactory &uri) {
+        for (const auto &[key, value] : request.params) {
+            if (key == "LongPollingIdx") {
+                // This parameter is not passed on, it just means we
+                // want to use long polling -- already handled
+            } else {
+                uri = std::move(uri).addQueryParameter(key, value);
+            }
         }
     }
 };


### PR DESCRIPTION
These changes make subscriptions work fine for me with RestBackend. I can now subscribe to "/DeviceName/Acquisition?channelNameFilter=saw" and i correctly receive the saw wave every 2 seconds as expected.

Ralph commented on chat:
> Sending through the pub socket should be default. Sending subscriptions through the router sockets is legacy/inefficient as it duplicates traffic for each client. Sending via the ROUTER-DEALER socket pair requires a unique id for each connection/client while the subsciotion requires only a single service/worker type id.

So that probably needs some looking into, I don't know why the router socket is used instead of the pub one. However this is enough for me to go forward with the UI work.