### PR TITLE
RestBackend: Use real zmq subscription

### DIFF
--- a/src/majordomo/include/majordomo/Broker.hpp
+++ b/src/majordomo/include/majordomo/Broker.hpp
@@ -524,6 +524,7 @@ private:
             it->second--;
             if (it->second == 0) {
                 zmq_invoke(zmq_setsockopt, _subSocket, ZMQ_UNSUBSCRIBE, topic.str().data(), topic.str().size()).assertSuccess();
+                _subscribedTopics.erase(it);
             }
         }
     }


### PR DESCRIPTION
 The current implementation uses the Request Socket to send a subscription mdp command instead of using the broker's pub/sub endpoint. Also the naming and usage of the different Sockets is inconsistent.
    
This changes the socket types and uses the SUB socket for subscriptions while using the dealer socket for get requests.

This might be incomplete and not handle every case and is not meant to be merged without further testing and discussion.