### PR TITLE
Frank/core fixes

### DIFF
--- a/src/core/include/URI.hpp
+++ b/src/core/include/URI.hpp
@@ -98,6 +98,9 @@ public:
         if (this == &other) {
             return *this;
         }
+
+        const char *oldBegin = other._str.data();
+
         std::swap(_str, other._str);
         std::swap(_scheme, other._scheme);
         std::swap(_authority, other._authority);
@@ -105,12 +108,29 @@ public:
         std::swap(_query, other._query);
         std::swap(_fragment, other._fragment);
         std::swap(_queryMap, other._queryMap);
-
         std::swap(_parsedAuthority, other._parsedAuthority);
         std::swap(_userName, other._userName);
         std::swap(_pwd, other._pwd);
         std::swap(_hostName, other._hostName);
         std::swap(_port, other._port);
+
+        // small strings are copied, then adjust views
+        if (_str.data() != oldBegin) {
+            auto adjustView = [this, oldBegin](std::string_view &view) {
+                view = std::string_view(_str.data() + std::distance(oldBegin, view.data()), view.size());
+            };
+
+            adjustView(_scheme);
+            adjustView(_authority);
+            adjustView(_path);
+            adjustView(_query);
+            adjustView(_fragment);
+            adjustView(_userName);
+            adjustView(_pwd);
+            adjustView(_hostName);
+            adjustView(_port);
+        }
+
         return *this;
     }
 

--- a/src/core/test/URI_tests.cpp
+++ b/src/core/test/URI_tests.cpp
@@ -121,6 +121,23 @@ TEST_CASE("Test for some previous issues", "[URI]") {
     using namespace opencmw;
     using QueryMap = std::unordered_map<std::string, std::optional<std::string>>;
 
+     // in the case of small-string optimization, the string_view accessors returned invalid data after movedFrom was destroyed
+    {
+        URI<STRICT> movedTo("/");
+        {
+            auto movedFrom = URI<STRICT>("s://u:p@h:1/p#f");
+            movedTo = std::move(movedFrom);
+        }
+        CHECK(movedTo.str() == "s://u:p@h:1/p#f");
+        CHECK(movedTo.scheme() == "s");
+        CHECK(movedTo.user() == "u");
+        CHECK(movedTo.password() == "p");
+        CHECK(movedTo.hostName() == "h");
+        CHECK(movedTo.port() == 1);
+        CHECK(movedTo.path() == "/p");
+        CHECK(movedTo.fragment() == "f");
+    }
+
     // parsing qas confused by ":" in the query param
     CHECK(URI<RELAXED>("/property?ctx=FAIR.SELECTOR.C=2:P=1").path() == "/property"); // path() == "P=1"
 

--- a/src/serialiser/include/IoBuffer.hpp
+++ b/src/serialiser/include/IoBuffer.hpp
@@ -6,6 +6,9 @@
 
 #include "MultiArray.hpp"
 #include "opencmw.hpp"
+
+#include <fmt/format.h>
+
 #include <algorithm>
 #include <array>
 #include <cassert>
@@ -455,6 +458,19 @@ public:
 };
 
 } // namespace opencmw
+
+template<>
+struct fmt::formatter<opencmw::IoBuffer> {
+    template<typename ParseContext>
+    constexpr auto parse(ParseContext &ctx) {
+        return ctx.begin(); // not (yet) implemented
+    }
+
+    template<typename FormatContext>
+    auto format(const opencmw::IoBuffer &v, FormatContext &ctx) const {
+        return fmt::format_to(ctx.out(), "{}", v.asString());
+    }
+};
 
 #pragma clang diagnostic pop
 #endif // OPENCMW_IOBUFFER_H

--- a/src/serialiser/include/IoBuffer.hpp
+++ b/src/serialiser/include/IoBuffer.hpp
@@ -165,7 +165,7 @@ public:
     }
 
     [[nodiscard]] explicit IoBuffer(const char *data)
-        : IoBuffer(data, std::strlen(data)) {}
+        : IoBuffer(data, data ? std::strlen(data) : 0) {}
 
     [[nodiscard]] explicit IoBuffer(const char *data, const std::size_t size, Allocator allocator = Allocator(Reallocator::defaultReallocator()))
         : IoBuffer(size, allocator) {

--- a/src/serialiser/test/IoBuffer_tests.cpp
+++ b/src/serialiser/test/IoBuffer_tests.cpp
@@ -42,6 +42,10 @@ TEST_CASE("IoBuffer(const char*) - constructor", "[IoBuffer]") {
         REQUIRE(a.asString() == "Hello World!");
         REQUIRE(a.size() == 12);
         REQUIRE(!a.empty());
+        opencmw::IoBuffer     null(nullptr);
+        REQUIRE(null.asString() == "");
+        REQUIRE(null.size() == 0);
+        REQUIRE(null.empty());
     }
 
     REQUIRE(opencmw::debug::alloc == opencmw::debug::dealloc); // a memory leak occurred


### PR DESCRIPTION
Fixes for IoBuffer (my own regression, sort of), and URI

Maybe URI shouldn't store string_view members, but string-independent (pos, size) pairs to indicate the substrings, and create the string_view's in the getters. That'd make assignment simpler and more robust.