### PR TITLE
Minor build system fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,7 @@ elseif (EMSCRIPTEN)
     # clang does not work with stdlib++ ranges, we have to use libc++
     # add_compile_options(-stdlib=libc++)
     # add_link_options(-stdlib=libc++ -lc++abi)
-    message(WARN "You are building with Emscripten Clang. Be advised that support is limited to working in conjunction with"
+    message(WARNING "You are building with Emscripten Clang. Be advised that support is limited to working in conjunction with"
             " libc++ and certain modules. libc++ has been enabled.")
     add_compile_options(-Wno-shorten-64-to-32 -fwasm-exceptions)
     add_link_options(-fwasm-exceptions -sFETCH=1)
@@ -40,7 +40,7 @@ elseif (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
         message(FATAL_ERROR "Clang>=15.0.0 required, but clang ${CMAKE_CXX_COMPILER_VERSION} detected.")
     endif ()
 else ()
-    message(WARN "No version check for your compiler (${CMAKE_CXX_COMPILER_ID}) implemented, "
+    message(WARNING "No version check for your compiler (${CMAKE_CXX_COMPILER_ID}) implemented, "
             "in case of build problems consider updating your compiler or check if you can switch to gcc or clang")
 endif ()
 

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -19,9 +19,7 @@ FetchContent_Declare(
         fmt
         GIT_REPOSITORY https://github.com/fmtlib/fmt.git
         GIT_TAG 8a21e328b8dcb62a2901c499598366a0f5f3f4a5 # magic, working version
-        PATCH_COMMAND git config user.name 'Anonymous'
-        COMMAND git config user.email '<>'
-        COMMAND git cherry-pick 90b68783fff695d6ad26a56550272edd43c57b44
+        PATCH_COMMAND git cherry-pick --no-commit 90b68783fff695d6ad26a56550272edd43c57b44
 )
 
 # dependency of mp-units, building examples, tests, etc is off by default

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -9,7 +9,7 @@ endif ()
 if (USE_LIBCPP)
         # does not work, because <source_location> and std::jthread is missing
         # also ranges support is not complete
-        message(WARN "Disabled majordomo and client module because they are not compatible with libc++")
+        message(WARNING "Disabled majordomo and client module because they are not compatible with libc++")
 else()
         add_subdirectory(majordomo)
         add_subdirectory(zmq)


### PR DESCRIPTION
This fixes two small problems I noticed in the cmake build system:

- Fix `WARNING` usage inside `message()`. Previously `WARN` was used, which doesn't actually exist as a `message()` mode, so instead it was silently prefixed to the string argument.
- Avoid cherry-picking patches as a different user: Some people like to gpg-sign their commits by default. If we let cmake commit with a different user, this will cause the commit to fail, because no GPG key matches the foreign address. To fix this, instead just apply the patch without committing which is also more in line with how distros would usually patch software (i.e. using the equivalent of `patch -Np1`). This also simplifies that cmake code a bit, as we no longer need to set a git user to accomodate people that haven't configured a git user yet.
