### PR TITLE
WIP Annotated Members in JSON

### DIFF
--- a/src/serialiser/test/IoSerialiserJson_tests.cpp
+++ b/src/serialiser/test/IoSerialiserJson_tests.cpp
@@ -278,4 +278,25 @@ TEST_CASE("consumeWhitespace", "[JsonSerialiser]") {
     REQUIRE(buffer.position() == 11);
 }
 
+struct TestStruct {
+    Annotated<long, units::isq::si::time<units::isq::si::microsecond>> member;
+
+    bool operator==(const TestStruct& other) {
+        return member == other.member;
+    }
+};
+ENABLE_REFLECTION_FOR(TestStruct, member)
+
+TEST_CASE("Annotated Members", "[JsonSerialiser]") {
+    TestStruct testObject{300}, outObject;
+    std::string serializedObject;
+    IoBuffer out;
+
+    serialise<Json>(out, testObject);
+    serializedObject = out.asString();
+
+    deserialise<Json, ProtocolCheck::ALWAYS>(out, outObject);
+
+    REQUIRE((testObject == outObject));
+}
 #pragma clang diagnostic pop


### PR DESCRIPTION
This PR is there to show a problem with our JSON serialiser.

I am trying to serialise a struct that has an annotated member, reserialising fails because no unit is attached.

```
mismatched field unit for TestStruct::member - requested unit 'us' received ''"
```