### PR TITLE
IoBuffer & IoSerialiserYaS improvements & {fmt} format fixes

### DIFF
--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -18,7 +18,7 @@ FetchContent_Declare(
 FetchContent_Declare(
         fmt
         GIT_REPOSITORY https://github.com/fmtlib/fmt.git
-        GIT_TAG 10.0.0
+        GIT_TAG 10.1.1
 )
 
 # dependency of mp-units, building examples, tests, etc is off by default

--- a/src/core/include/opencmw.hpp
+++ b/src/core/include/opencmw.hpp
@@ -182,20 +182,20 @@ concept Duration = is_duration<T>::value;
 
 namespace detail {
 
-    template<typename Out, typename... Ts>
-    struct filter_tuple : std::type_identity<Out> {};
+template<typename Out, typename... Ts>
+struct filter_tuple : std::type_identity<Out> {};
 
-    template<typename... Out, typename InCar, typename... InCdr> // template for std::tuple arguments
-    struct filter_tuple<std::tuple<Out...>, std::tuple<InCar, InCdr...>>
-        : std::conditional_t<(std::is_same_v<InCar, Out> || ...),
-                  filter_tuple<std::tuple<Out...>, std::tuple<InCdr...>>,
-                  filter_tuple<std::tuple<Out..., InCar>, std::tuple<InCdr...>>> {};
+template<typename... Out, typename InCar, typename... InCdr> // template for std::tuple arguments
+struct filter_tuple<std::tuple<Out...>, std::tuple<InCar, InCdr...>>
+    : std::conditional_t<(std::is_same_v<InCar, Out> || ...),
+              filter_tuple<std::tuple<Out...>, std::tuple<InCdr...>>,
+              filter_tuple<std::tuple<Out..., InCar>, std::tuple<InCdr...>>> {};
 
-    template<typename Out, typename... Ts>
-    struct filter_tuple2 : std::type_identity<Out> {};
+template<typename Out, typename... Ts>
+struct filter_tuple2 : std::type_identity<Out> {};
 
-    template<typename... Ts, typename U, typename... Us> // template for variadic arguments returning std::tuple
-    struct filter_tuple2<std::tuple<Ts...>, U, Us...> : std::conditional_t<(std::is_same_v<U, Ts> || ...), filter_tuple2<std::tuple<Ts...>, Us...>, filter_tuple2<std::tuple<Ts..., U>, Us...>> {};
+template<typename... Ts, typename U, typename... Us> // template for variadic arguments returning std::tuple
+struct filter_tuple2<std::tuple<Ts...>, U, Us...> : std::conditional_t<(std::is_same_v<U, Ts> || ...), filter_tuple2<std::tuple<Ts...>, Us...>, filter_tuple2<std::tuple<Ts..., U>, Us...>> {};
 
 } // namespace detail
 
@@ -208,7 +208,8 @@ template<typename... T>
 constexpr bool is_tuple<std::tuple<T...>> = true;
 
 template<class T>
-requires(is_tuple<T>) using tuple_unique = typename detail::filter_tuple<std::tuple<>, T>::type;
+    requires(is_tuple<T>)
+using tuple_unique = typename detail::filter_tuple<std::tuple<>, T>::type;
 
 template<template<typename...> typename Type, typename... Items>
 using find_type = decltype(std::tuple_cat(std::declval<std::conditional_t<is_instance_of_v<Items, Type>, std::tuple<Items>, std::tuple<>>>()...));
@@ -223,7 +224,8 @@ template<>
 struct is_uniq<> : std::true_type {};
 
 template<typename T0, typename... Ts>
-requires(!is_in_list<T0, Ts...>::value) struct is_uniq<T0, Ts...> : is_uniq<Ts...> {};
+    requires(!is_in_list<T0, Ts...>::value)
+struct is_uniq<T0, Ts...> : is_uniq<Ts...> {};
 
 template<typename... Ts>
 struct type_list {};
@@ -239,12 +241,14 @@ struct filter_dups_impl<C, type_list<Uniqs...>, type_list<>> {
 };
 
 template<template<typename...> class C, typename... Uniqs, typename Input0, typename... Inputs>
-requires(... && !std::same_as<Input0, Uniqs>) struct filter_dups_impl<C, type_list<Uniqs...>, type_list<Input0, Inputs...>>
+    requires(... && !std::same_as<Input0, Uniqs>)
+struct filter_dups_impl<C, type_list<Uniqs...>, type_list<Input0, Inputs...>>
     : filter_dups_impl<C, type_list<Uniqs..., Input0>, type_list<Inputs...>> {
 };
 
 template<template<typename...> class C, typename... Uniqs, typename Input0, typename... Inputs>
-requires(... || std::same_as<Input0, Uniqs>) struct filter_dups_impl<C, type_list<Uniqs...>, type_list<Input0, Inputs...>>
+    requires(... || std::same_as<Input0, Uniqs>)
+struct filter_dups_impl<C, type_list<Uniqs...>, type_list<Input0, Inputs...>>
     : filter_dups_impl<C, type_list<Uniqs...>, type_list<Inputs...>> {};
 
 template<template<typename...> class C, typename... Ts>
@@ -480,7 +484,7 @@ template<typename T> requires is_same_v<std::remove_const_t<T>, float_t>   inlin
 template<typename T> requires is_same_v<std::remove_const_t<T>, double_t>  inline constexpr const std::string_view typeName<T> = std::is_const_v<T> ? "double_t const" : "double_t";
 
 template<StringLike T> requires units::is_derived_from_specialization_of<T, std::basic_string> inline constexpr const std::string_view typeName<T> = std::is_const_v<T> ? "string const" : "string";
-template<StringLike T> requires units::is_derived_from_specialization_of<T, std::basic_string_view> inline constexpr const std::string_view typeName<T> = std::is_const_v<T> ? "string const" : "string";
+template<StringLike T> requires units::is_derived_from_specialization_of<T, std::basic_string_view> inline constexpr const std::string_view typeName<T> = std::is_const_v<T> ? "string_view const" : "string_view";
 
 template<typename T, std::size_t N> inline const std::string &typeName<std::array<T,N>> = fmt::format("array<{},{}>", typeName<T>, N);
 template<typename T, std::size_t N> inline const std::string &typeName<std::array<T,N> const> = fmt::format("array<{},{}> const", typeName<T>, N);

--- a/src/serialiser/include/IoSerialiser.hpp
+++ b/src/serialiser/include/IoSerialiser.hpp
@@ -452,15 +452,13 @@ struct fmt::formatter<opencmw::ProtocolCheck> {
 
     template<typename FormatContext>
     auto format(opencmw::ProtocolCheck const &v, FormatContext &ctx) const {
+        using enum opencmw::ProtocolCheck;
         switch (v) {
-        case opencmw::ProtocolCheck::IGNORE:
-            break;
+        case IGNORE:
             return fmt::format_to(ctx.out(), "IGNORE");
-        case opencmw::ProtocolCheck::LENIENT:
-            break;
+        case LENIENT:
             return fmt::format_to(ctx.out(), "LENIENT");
-        case opencmw::ProtocolCheck::ALWAYS:
-            break;
+        case ALWAYS:
             return fmt::format_to(ctx.out(), "ALWAYS");
         default:
             return ctx.out();

--- a/src/serialiser/include/IoSerialiserYaS.hpp
+++ b/src/serialiser/include/IoSerialiserYaS.hpp
@@ -294,7 +294,6 @@ struct FieldHeaderWriter<YaS> {
         // -- offset 0 vs. field start
         field.headerStart = buffer.size();
         buffer.put(IoSerialiser<YaS, StrippedDataType>::getDataTypeId()); // data type ID
-        buffer.put(opencmw::hash(field.fieldName));                       // unique hashCode identifier
         const std::size_t dataStartOffsetPosition = buffer.size();
         buffer.put(-1); // dataStart offset
         const std::size_t dataSizePosition = buffer.size();
@@ -377,10 +376,8 @@ template<>
 struct FieldHeaderReader<YaS> {
     template<ProtocolCheck check>
     inline static void get(IoBuffer &buffer, const DeserialiserInfo & /*info*/, FieldDescriptionLong &result) {
-        result.headerStart = buffer.position();
-        result.intDataType = buffer.get<uint8_t>(); // data type ID
-        // const auto        hashFieldName     =
-        buffer.get<int32_t>(); // hashed field name -> future: faster look-up/matching of fields
+        result.headerStart         = buffer.position();
+        result.intDataType         = buffer.get<uint8_t>(); // data type ID
         const auto dataStartOffset = static_cast<uint64_t>(buffer.get<int32_t>());
         const auto dataSize        = static_cast<uint64_t>(buffer.get<int32_t>());
         result.fieldName           = buffer.get<std::string_view>(); // full field name

--- a/src/serialiser/test/IoBuffer_tests.cpp
+++ b/src/serialiser/test/IoBuffer_tests.cpp
@@ -140,7 +140,6 @@ TEST_CASE("IoBuffer syntax - primitives", "[IoBuffer]") {
         REQUIRE(43 == test1a);
         test1a = 5;
         REQUIRE(5 == test1a);
-        REQUIRE(43 == a.get<int8_t>(0));
         auto &test1b = a.at<int8_t>(0); // test1b refers to actual IoBuffer memory block
         REQUIRE(43 == test1b);
         a.at<short>(0) = 5;           // '0' == index within IoBuffer
@@ -319,7 +318,7 @@ TEST_CASE("IoBuffer syntax - arrays", "[IoBuffer]") {
         // variant A: allocating a new vector
         std::vector<int> recoveredIntVector = buffer.getArray<int>();
         REQUIRE(inputIntVector == recoveredIntVector);
-        REQUIRE(inputIntVector == buffer.getArray<int>(recoveredIntVector, static_cast<size_t>(5)));
+        REQUIRE(inputIntVector == buffer.getArray(recoveredIntVector, static_cast<size_t>(5)));
         // PRINT_VECTOR(recoveredIntVector1);
 
         // variant B: re-using existing vector
@@ -334,12 +333,12 @@ TEST_CASE("IoBuffer syntax - arrays", "[IoBuffer]") {
         REQUIRE(array == array2);
 
         // bool vector & bool array
-        REQUIRE(std::vector<bool>{ false, true, false, true, false } == buffer.getArray<bool>(std::vector<bool>(), 5));
-        REQUIRE(std::array<bool, 5>{ true, false, true, false, true } == buffer.getArray<bool, 5>(std::array<bool, 5>(), 5));
+        REQUIRE(std::vector<bool>{ false, true, false, true, false } == buffer.getArray(std::vector<bool>(), 5));
+        REQUIRE(std::array<bool, 5>{ true, false, true, false, true } == buffer.getArray(std::array<bool, 5>(), 5));
 
         const auto         origPosition = buffer.position();
         std::array<int, 5> array3{ 0, 0, 0, 0, 0 };
-        REQUIRE(array == buffer.getArray<int, 5>(array3, 5));
+        REQUIRE(array == buffer.getArray(array3, 5));
         // PRINT_VECTOR(array3);
         //  read unnamed array
         buffer.set_position(origPosition); // skip back

--- a/src/serialiser/test/IoSerialiserYaS_tests.cpp
+++ b/src/serialiser/test/IoSerialiserYaS_tests.cpp
@@ -292,9 +292,9 @@ TEST_CASE("IoClassSerialiser basic typeName tests", "[IoClassSerialiser]") {
         REQUIRE(typeName<float_t const> == "float_t const");
 
         REQUIRE(typeName<std::string> == "string");
-        REQUIRE(typeName<std::string_view> == "string");
+        REQUIRE(typeName<std::string_view> == "string_view");
         REQUIRE(typeName<std::string const> == "string const");
-        REQUIRE(typeName<std::string_view const> == "string const");
+        REQUIRE(typeName<std::string_view const> == "string_view const");
     }
     REQUIRE(opencmw::debug::dealloc == opencmw::debug::alloc); // a memory leak occurred
     debug::resetStats();


### PR DESCRIPTION
## IoBuffer & IoSerialiserYaS improvements & {fmt} format fixes

* bumped fmt version and fixed formatter
* IoBuffer: simplified templating and added endianness awareness, aiming at:
  * minimising use of reinterpret_cast (or at least limit this to fewer cases)
  * minimising use of raw pointer in public API
  * reducing non-functional code-duplication
* IoSerialiserYaS: removed unused fieldname hash


No performance regression, rather a slight improvement on all serialisers:
```cpp
Before:
┌─protocol─┬────────ALWAYS─────────┬────────LENIENT────────┬────────IGNORE─────────┐
│   YAML   │131.8 MB/s ± 547.8 kB/s│127.4 MB/s ± 147.6 kB/s│132.1 MB/s ± 190.4 kB/s│
│   Json   │305.1 MB/s ±   1.6 MB/s│301.4 MB/s ±   1.5 MB/s│305.4 MB/s ±   2.1 MB/s│
│   YaS    │  7.0 GB/s ±  14.6 MB/s│  6.4 GB/s ±   6.0 MB/s│  7.8 GB/s ±  10.2 MB/s│
│ CmwLight │  8.1 GB/s ±  13.7 MB/s│  7.7 GB/s ±  11.9 MB/s│  8.5 GB/s ±  12.1 MB/s│
└──────────┴───────────────────────┴───────────────────────┴───────────────────────┘
After IoBuffer clean-up:
┌─protocol─┬────────ALWAYS─────────┬────────LENIENT────────┬────────IGNORE─────────┐
│   YAML   │127.2 MB/s ±   2.0 MB/s│129.5 MB/s ± 401.7 kB/s│127.5 MB/s ± 272.4 kB/s│
│   Json   │314.3 MB/s ±   1.5 MB/s│315.0 MB/s ±   1.8 MB/s│316.4 MB/s ±   1.8 MB/s│
│   YaS    │  6.9 GB/s ±  36.5 MB/s│  6.4 GB/s ±  18.6 MB/s│  7.5 GB/s ±  40.3 MB/s│
│ CmwLight │  8.0 GB/s ±  40.2 MB/s│  7.7 GB/s ±  54.9 MB/s│  8.5 GB/s ±  39.0 MB/s│
└──────────┴───────────────────────┴───────────────────────┴───────────────────────┘
After YaS unused fieldname hash removal:
┌─protocol─┬────────ALWAYS─────────┬────────LENIENT────────┬────────IGNORE─────────┐
│   YAML   │126.9 MB/s ± 582.4 kB/s│127.0 MB/s ± 305.6 kB/s│127.0 MB/s ± 420.9 kB/s│
│   Json   │300.2 MB/s ±   2.2 MB/s│303.6 MB/s ±   1.8 MB/s│301.5 MB/s ±   1.9 MB/s│
│   YaS    │  7.2 GB/s ±  30.5 MB/s│  6.6 GB/s ±  20.5 MB/s│  8.0 GB/s ±  37.0 MB/s│
│ CmwLight │  8.0 GB/s ±  36.2 MB/s│  7.7 GB/s ±  17.3 MB/s│  8.7 GB/s ±  68.3 MB/s│
└──────────┴───────────────────────┴───────────────────────┴───────────────────────┘
````