### PR TITLE
Fix subscription topic handling

### DIFF
--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -82,7 +82,7 @@ jobs:
 
     - name: Install sonar-scanner and build-wrapper
       if: matrix.configurations.name == env.REFERENCE_CONFIG && matrix.cmake-build-type == 'Debug'
-      uses: SonarSource/sonarcloud-github-c-cpp@v1
+      uses: SonarSource/sonarcloud-github-c-cpp@v2
 
     - name: Configure CMake
       if: matrix.configurations.compiler != 'emscripten'

--- a/concepts/majordomo/helpers.hpp
+++ b/concepts/majordomo/helpers.hpp
@@ -281,7 +281,7 @@ public:
         return zmq::invoke(zmq_bind, _socket, mdp::toZeroMQEndpoint(address).data()).isValid();
     }
 
-    bool connect(const opencmw::URI<opencmw::STRICT> &address, std::string_view subscription = "") {
+    bool connect(const opencmw::URI<opencmw::STRICT> &address, const mdp::SubscriptionTopic &subscription = {}) {
         auto result = zmq::invoke(zmq_connect, _socket, mdp::toZeroMQEndpoint(address).data());
         if (!result) return false;
 
@@ -292,14 +292,16 @@ public:
         return true;
     }
 
-    bool subscribe(std::string_view subscription) {
-        assert(!subscription.empty());
-        return zmq::invoke(zmq_setsockopt, _socket, ZMQ_SUBSCRIBE, subscription.data(), subscription.size()).isValid();
+    bool subscribe(const mdp::SubscriptionTopic &subscription) {
+        const auto topic = subscription.toZmqTopic();
+        assert(!topic.empty());
+        return zmq::invoke(zmq_setsockopt, _socket, ZMQ_SUBSCRIBE, topic.data(), topic.size()).isValid();
     }
 
-    bool unsubscribe(std::string_view subscription) {
-        assert(!subscription.empty());
-        return zmq::invoke(zmq_setsockopt, _socket, ZMQ_UNSUBSCRIBE, subscription.data(), subscription.size()).isValid();
+    bool unsubscribe(const mdp::SubscriptionTopic &subscription) {
+        const auto topic = subscription.toZmqTopic();
+        assert(!topic.empty());
+        return zmq::invoke(zmq_setsockopt, _socket, ZMQ_UNSUBSCRIBE, topic.data(), topic.size()).isValid();
     }
 
     bool sendRawFrame(std::string data) {
@@ -402,8 +404,8 @@ public:
 
 class NonCopyableMovableHandler {
 public:
-    NonCopyableMovableHandler()                                      = default;
-    NonCopyableMovableHandler(NonCopyableMovableHandler &&) noexcept = default;
+    NonCopyableMovableHandler()                                                 = default;
+    NonCopyableMovableHandler(NonCopyableMovableHandler &&) noexcept            = default;
     NonCopyableMovableHandler &operator=(NonCopyableMovableHandler &&) noexcept = default;
 
     void                       operator()(opencmw::majordomo::RequestContext &) {}

--- a/src/client/include/MockServer.hpp
+++ b/src/client/include/MockServer.hpp
@@ -15,7 +15,7 @@
 namespace opencmw::majordomo {
 
 /*
- * Very simple mock opencmw server to use for testing. Offers a single int property named "a.service" which can be get/set/subscribed.
+ * Very simple mock opencmw server to use for testing.
  * Does not do any processing on its own, all actions have to be queried explicitly by calling the respective handler.
  * This allows single threaded and reproducible testing of client logic.
  */
@@ -91,29 +91,15 @@ public:
         return true;
     }
 
-    void notify(std::string_view topic, std::string_view value) {
-        auto                                                brokerName  = "";
-        auto                                                serviceName = "a.service";
+    void notify(const mdp::SubscriptionTopic &topic, std::string_view value) {
+        static const auto                                   brokerName  = "";
+        static const auto                                   serviceName = "a.service";
         mdp::BasicMessage<mdp::MessageFormat::WithSourceId> notify;
         notify.protocolName    = mdp::clientProtocol;
         notify.command         = mdp::Command::Final;
         notify.serviceName     = serviceName;
-        notify.endpoint        = mdp::Message::URI(std::string(topic));
-        notify.sourceId        = std::string(topic);
-        notify.clientRequestID = IoBuffer(brokerName);
-        notify.data            = IoBuffer(value.data(), value.size());
-        zmq::send(std::move(notify), _pubSocket.value()).assertSuccess();
-    }
-
-    void notify(std::string_view topic, std::string_view uri, std::string_view value) {
-        auto                                                brokerName  = "";
-        auto                                                serviceName = "a.service";
-        mdp::BasicMessage<mdp::MessageFormat::WithSourceId> notify;
-        notify.protocolName    = mdp::clientProtocol;
-        notify.command         = mdp::Command::Final;
-        notify.serviceName     = serviceName;
-        notify.endpoint        = mdp::Message::URI(std::string(uri));
-        notify.sourceId        = topic;
+        notify.endpoint        = topic.toEndpoint();
+        notify.sourceId        = topic.toZmqTopic();
         notify.clientRequestID = IoBuffer(brokerName);
         notify.data            = IoBuffer(value.data(), value.size());
         zmq::send(std::move(notify), _pubSocket.value()).assertSuccess();

--- a/src/client/test/ClientPublisher_tests.cpp
+++ b/src/client/test/ClientPublisher_tests.cpp
@@ -69,7 +69,7 @@ TEST_CASE("Basic subscription test", "[ClientContext]") {
     ClientContext clientContext{ std::move(clients) };
     std::this_thread::sleep_for(100ms);
     // subscription
-    auto             endpoint = URI<STRICT>::factory(URI<STRICT>(server.addressSub())).scheme("mds").path("/a.service").addQueryParameter("C", "2").build();
+    auto             endpoint = URI<STRICT>::factory(URI<STRICT>(server.addressSub())).scheme("mds").path("/a.topic").addQueryParameter("C", "2").build();
     std::atomic<int> received{ 0 };
     clientContext.subscribe(endpoint, [&received, &payload](const Message &update) {
         if (update.data.size() == payload.size()) {
@@ -79,7 +79,7 @@ TEST_CASE("Basic subscription test", "[ClientContext]") {
     std::this_thread::sleep_for(100ms); // allow for the subscription request to be processed
     // send notifications
     for (int i = 0; i < 100; i++) {
-        server.notify(*endpoint.relativeRefNoFragment(), payload);
+        server.notify(mdp::SubscriptionTopic::fromURI(endpoint), payload);
     }
     std::this_thread::sleep_for(10ms); // allow for all the notifications to reach the client
     fmt::print("received notifications {}\n", received.load());

--- a/src/client/test/MockServerTest.cpp
+++ b/src/client/test/MockServerTest.cpp
@@ -62,11 +62,11 @@ TEST_CASE("MockServer Subscription Test", "[mock-server][lambda_handler]") {
     BrokerMessageNode client(context, ZMQ_SUB);
     REQUIRE(client.connect(opencmw::URI<>(server.addressSub())));
 
-    client.subscribe("a.service");
+    client.subscribe(mdp::SubscriptionTopic("a.topic"));
     std::this_thread::sleep_for(10ms); // wait for the subscription to be set-up. todo: investigate more clever way
 
-    server.notify("a.service", "100");
-    server.notify("a.service", "23");
+    server.notify(mdp::SubscriptionTopic("a.topic"), "100");
+    server.notify(mdp::SubscriptionTopic("a.topic"), "23");
 
     {
         auto reply = client.tryReadOne();
@@ -74,7 +74,7 @@ TEST_CASE("MockServer Subscription Test", "[mock-server][lambda_handler]") {
         REQUIRE(reply);
         REQUIRE(reply->data.asString() == "100");
         REQUIRE(reply->command == mdp::Command::Final);
-        REQUIRE(reply->endpoint.str() == "a.service");
+        REQUIRE(reply->endpoint.str() == "/a.topic");
     }
     {
         auto reply = client.tryReadOne();
@@ -82,16 +82,16 @@ TEST_CASE("MockServer Subscription Test", "[mock-server][lambda_handler]") {
         REQUIRE(reply);
         REQUIRE(reply->data.asString() == "23");
         REQUIRE(reply->command == mdp::Command::Final);
-        REQUIRE(reply->endpoint.str() == "a.service");
+        REQUIRE(reply->endpoint.str() == "/a.topic");
     }
 
-    server.notify("a.service", "10");
+    server.notify(mdp::SubscriptionTopic("a.topic"), "10");
     {
         auto reply = client.tryReadOne();
         fmt::print("{}\n", reply.has_value());
         REQUIRE(reply);
         REQUIRE(reply->data.asString() == "10");
         REQUIRE(reply->command == mdp::Command::Final);
-        REQUIRE(reply->endpoint.str() == "a.service");
+        REQUIRE(reply->endpoint.str() == "/a.topic");
     }
 }

--- a/src/core/include/SubscriptionTopic.hpp
+++ b/src/core/include/SubscriptionTopic.hpp
@@ -1,0 +1,169 @@
+#ifndef OPENCMW_CORE_SUBSCRIPTIONTOPIC_H
+#define OPENCMW_CORE_SUBSCRIPTIONTOPIC_H
+
+#include <TimingCtx.hpp> // hash_combine
+#include <URI.hpp>
+
+#include <optional>
+#include <string>
+#include <unordered_map>
+
+#include <fmt/format.h>
+
+namespace opencmw::mdp {
+
+using namespace std::string_literals;
+
+//
+// Using strings (even URI-formatted) opens up users to
+// create invalid service-topic-parameters combinations.
+// SubscriptionTopic serves to make sure the information
+// about subscription is passable in a unified manner
+// (serializable and deserializable to a string/URI).
+//
+struct SubscriptionTopic {
+    using map = std::unordered_map<std::string, std::optional<std::string>>;
+
+private:
+    std::string        _service;
+    std::string        _path;
+    map                _params;
+
+    static std::string stripSlashes(std::string_view str, bool addLeadingSlash) {
+        auto firstNonSlash = str.find_first_not_of("/ ");
+        if (firstNonSlash == std::string::npos) {
+            return "";
+        }
+
+        auto lastNonSlash = str.find_last_not_of("/ ");
+
+        if (addLeadingSlash) {
+            return "/"s + std::string(str.data() + firstNonSlash, lastNonSlash - firstNonSlash + 1);
+        } else {
+            return std::string(str.data() + firstNonSlash, lastNonSlash - firstNonSlash + 1);
+        }
+    }
+
+public:
+    SubscriptionTopic() = default;
+
+    template<typename PathString>
+    explicit SubscriptionTopic(PathString &&path)
+        : SubscriptionTopic(""s, std::forward<PathString>(path), {}) {}
+
+    SubscriptionTopic(const SubscriptionTopic &other)               = default;
+    SubscriptionTopic &operator=(const SubscriptionTopic &)         = default;
+    SubscriptionTopic(SubscriptionTopic &&) noexcept                = default;
+    SubscriptionTopic &operator=(SubscriptionTopic &&) noexcept     = default;
+
+    auto               operator<=>(const SubscriptionTopic &) const = default;
+
+    template<typename TURI>
+    static SubscriptionTopic fromURI(const TURI &uri) {
+        return SubscriptionTopic(""s, uri.path().value_or(""s), uri.queryParamMap());
+    }
+
+    template<typename TURI, typename ServiceString>
+    static SubscriptionTopic fromURIAndServiceName(const TURI &uri, ServiceString &&serviceName) {
+        return SubscriptionTopic(std::forward<ServiceString>(serviceName), uri.path().value_or(""s), uri.queryParamMap());
+    }
+
+    opencmw::URI<STRICT> toEndpoint() const {
+        return opencmw::URI<STRICT>::factory().path(_path).setQuery(_params).build();
+    }
+
+    bool empty() const {
+        return _service.empty() && _path.empty() && _params.empty();
+    }
+
+    std::string toZmqTopic() const {
+        std::string topic = _path;
+        if (_params.empty()) {
+            return topic;
+        }
+        topic += "?"s;
+        bool isFirst = true;
+        // sort params
+        for (const auto &[key, value] : std::map{ _params.begin(), _params.end() }) {
+            if (!isFirst) {
+                topic += "&"s;
+            }
+            topic += key;
+            if (value) {
+                topic += "="s + opencmw::URI<>::encode(*value);
+            }
+            isFirst = false;
+        }
+        return topic;
+    }
+
+    [[nodiscard]] std::size_t hash() const noexcept {
+        std::size_t seed = 0;
+        opencmw::detail::hash_combine(seed, _service);
+        opencmw::detail::hash_combine(seed, _path);
+        for (const auto &[key, value] : _params) {
+            opencmw::detail::hash_combine(seed, key);
+            opencmw::detail::hash_combine(seed, value);
+        }
+
+        return seed;
+    }
+
+    std::string_view path() const { return _path; }
+    std::string_view service() const { return _service; }
+    const auto      &params() const { return _params; }
+
+private:
+    template<typename ServiceString, typename PathString>
+    SubscriptionTopic(ServiceString &&service, PathString &&path, std::unordered_map<std::string, std::optional<std::string>> params)
+        : _service(stripSlashes(std::forward<ServiceString>(service), false))
+        , _path(stripSlashes(std::forward<PathString>(path), true))
+        , _params(std::move(params)) {
+        if (_path.find("?") != std::string::npos) {
+            if (_params.size() != 0) {
+                throw fmt::format("Parameters are not empty, and there are more in the path {} {}\n", _params, _path);
+            }
+            auto parsed = opencmw::URI<RELAXED>(_path);
+            _path       = parsed.path().value_or("/");
+            _params     = parsed.queryParamMap();
+        }
+
+        auto is_char_valid = [](char c) {
+            return std::isalnum(c) || c == '.';
+        };
+
+        if (!std::all_of(_service.cbegin(), _service.cbegin(), is_char_valid)) {
+            throw fmt::format("Invalid service name {}\n", _service);
+        }
+        if (!std::all_of(_path.cbegin(), _path.cbegin(), is_char_valid)) {
+            throw fmt::format("Invalid path {}\n", _path);
+        }
+    }
+};
+
+} // namespace opencmw::mdp
+
+template<>
+struct fmt::formatter<opencmw::mdp::SubscriptionTopic> {
+    template<typename ParseContext>
+    constexpr auto parse(ParseContext &ctx) {
+        return ctx.begin();
+    }
+
+    template<typename FormatContext>
+    auto format(const opencmw::mdp::SubscriptionTopic &v, FormatContext &ctx) const {
+        return fmt::format_to(ctx.out(), "[service:{}, path:{}, params:{}]", v.service(), v.path(), v.params());
+    }
+};
+
+namespace std {
+template<>
+struct hash<opencmw::mdp::SubscriptionTopic> {
+    std::size_t operator()(const opencmw::mdp::SubscriptionTopic &k) const {
+        return k.hash();
+    }
+};
+
+} // namespace std
+
+#endif

--- a/src/core/include/SubscriptionTopic.hpp
+++ b/src/core/include/SubscriptionTopic.hpp
@@ -48,6 +48,7 @@ public:
     SubscriptionTopic() = default;
 
     template<typename PathString>
+        requires(!std::same_as<SubscriptionTopic, std::remove_cvref_t<PathString>>)
     explicit SubscriptionTopic(PathString &&path)
         : SubscriptionTopic(""s, std::forward<PathString>(path), {}) {}
 

--- a/src/majordomo/include/majordomo/Broker.hpp
+++ b/src/majordomo/include/majordomo/Broker.hpp
@@ -514,8 +514,7 @@ private:
         auto [it, inserted] = _subscribedTopics.try_emplace(topic, 0);
         it->second++;
         if (it->second == 1) {
-            // auto topicStr = topic.serialized();
-            auto topicStr = topic.path();
+            const auto topicStr = topic.serialized();
             zmq::invoke(zmq_setsockopt, _subSocket, ZMQ_SUBSCRIBE, topicStr.data(), topicStr.size()).assertSuccess();
         }
     }
@@ -525,7 +524,7 @@ private:
         if (it != _subscribedTopics.end()) {
             it->second--;
             if (it->second == 0) {
-                auto topicStr = topic.serialized();
+                const auto topicStr = topic.serialized();
                 zmq::invoke(zmq_setsockopt, _subSocket, ZMQ_UNSUBSCRIBE, topicStr.data(), topicStr.size()).assertSuccess();
                 _subscribedTopics.erase(it);
             }
@@ -581,7 +580,7 @@ private:
                 return true;
             }
             case mdp::Command::Subscribe: {
-                SubscriptionData subscription(message.serviceName, message.endpoint.str(), {});
+                const auto subscription = SubscriptionData::fromURIAndServiceName(message.endpoint, message.serviceName);
 
                 subscribe(subscription);
 
@@ -590,7 +589,7 @@ private:
                 return true;
             }
             case mdp::Command::Unsubscribe: {
-                SubscriptionData subscription(message.serviceName, message.endpoint.str(), {});
+                const auto subscription = SubscriptionData::fromURIAndServiceName(message.endpoint, message.serviceName);
 
                 unsubscribe(subscription);
 
@@ -678,7 +677,7 @@ private:
     }
 
     void dispatchMessageToMatchingSubscribers(BrokerMessage &&message) {
-        SubscriptionData subscription(message.serviceName, message.endpoint.str(), {});
+        const auto subscription = SubscriptionData::fromURIAndServiceName(message.endpoint, message.serviceName);
 
         // TODO avoid clone() for last message sent out
         for (const auto &[topic, _] : _subscribedTopics) {

--- a/src/majordomo/include/majordomo/RestBackend.hpp
+++ b/src/majordomo/include/majordomo/RestBackend.hpp
@@ -251,9 +251,9 @@ public:
         , requestResponseSocket(context, ZMQ_SUB)
         , subscriptionInfo(std::move(_subscriptionInfo)) {}
 
-    Connection(const Connection &other) = delete;
+    Connection(const Connection &other)       = delete;
     Connection &operator=(const Connection &) = delete;
-    Connection &operator=(Connection &&) = delete;
+    Connection &operator=(Connection &&)      = delete;
 
     // Here be dragons! This is not to be used after
     // the connection was involved in any threading code

--- a/src/majordomo/include/majordomo/SubscriptionMatcher.hpp
+++ b/src/majordomo/include/majordomo/SubscriptionMatcher.hpp
@@ -91,6 +91,11 @@ public:
         return SubscriptionData(""s, uri.path().value_or(""s), uri.queryParamMap());
     }
 
+    template<typename TURI>
+    static SubscriptionData fromURIAndServiceName(const TURI &uri, std::string_view serviceName) {
+       return SubscriptionData(serviceName, uri.path().value_or(""s), uri.queryParamMap());
+    }
+
     std::string serialized() const {
         return URI<RELAXED>::factory().path(std::string(_path)).setQuery(_params).build().str();
     }

--- a/src/majordomo/include/majordomo/SubscriptionMatcher.hpp
+++ b/src/majordomo/include/majordomo/SubscriptionMatcher.hpp
@@ -2,145 +2,11 @@
 #define OPENCMW_MAJORDOMO_SUBSCRIPTIONMATCHER_H
 
 #include <Filters.hpp>
+#include <SubscriptionTopic.hpp>
 #include <TimingCtx.hpp>
-#include <URI.hpp>
 
 #include <concepts>
 #include <memory>
-#include <optional>
-
-namespace opencmw::majordomo {
-
-using namespace std::string_literals;
-
-//
-// Using strings (even URI-formatted) opens up users to
-// create invalid service-topic-parameters combinations.
-// SubscriptionData serves to make sure the information
-// about subscription is passable in a unified manner
-// (serializable and deserializable to a string/URI).
-//
-struct SubscriptionData {
-    using map = std::unordered_map<std::string, std::optional<std::string>>;
-
-private:
-    std::string        _service;
-    std::string        _path;
-    map                _params;
-
-    static std::string stripSlashes(std::string_view str, bool addLeadingSlash) {
-        auto firstNonSlash = str.find_first_not_of("/ ");
-        if (firstNonSlash == std::string::npos) {
-            return "";
-        }
-
-        auto lastNonSlash = str.find_last_not_of("/ ");
-
-        if (addLeadingSlash) {
-            return "/"s + std::string(str.data() + firstNonSlash, lastNonSlash - firstNonSlash + 1);
-        } else {
-            return std::string(str.data() + firstNonSlash, lastNonSlash - firstNonSlash + 1);
-        }
-    }
-
-public:
-    template<typename ServiceString, typename PathString>
-    SubscriptionData(ServiceString &&service, PathString &&path, std::unordered_map<std::string, std::optional<std::string>> params)
-        : _service(stripSlashes(std::forward<ServiceString>(service), false))
-        , _path(stripSlashes(std::forward<PathString>(path), true))
-        , _params(std::move(params)) {
-        if (_path.find("?") != std::string::npos) {
-            if (_params.size() != 0) {
-                throw fmt::format("Parameters are not empty, and there are more in the path {} {}\n", _params, _path);
-            }
-            auto oldPath = _path;
-            auto parsed  = URI<RELAXED>(_path);
-            _path        = parsed.path().value_or("/");
-            _params      = parsed.queryParamMap();
-        }
-
-        auto is_char_valid = [](char c) {
-            return std::isalnum(c) || c == '.';
-        };
-
-        if (!std::all_of(_service.cbegin(), _service.cbegin(), is_char_valid)) {
-            throw fmt::format("Invalid service name {}\n", _service);
-        }
-        if (!std::all_of(_path.cbegin(), _path.cbegin(), is_char_valid)) {
-            throw fmt::format("Invalid path {}\n", _path);
-        }
-    }
-
-    SubscriptionData(const SubscriptionData &other)
-        : SubscriptionData(other._service, other._path, other._params) {}
-
-    SubscriptionData(SubscriptionData &&other)
-        : SubscriptionData(std::move(other._service), std::move(other._path), std::move(other._params)) {}
-
-    SubscriptionData &operator=(SubscriptionData other) = delete;
-
-    bool              operator==(const SubscriptionData &other) const {
-        return std::tie(_service, _path, _params) == std::tie(other._service, other._path, other._params);
-    }
-
-    bool operator!=(const SubscriptionData &other) const {
-        return !operator==(other);
-    }
-
-    static SubscriptionData fromURI(const URI<RELAXED> &uri) {
-        return SubscriptionData(""s, uri.path().value_or(""s), uri.queryParamMap());
-    }
-
-    template<typename TURI>
-    static SubscriptionData fromURIAndServiceName(const TURI &uri, std::string_view serviceName) {
-       return SubscriptionData(serviceName, uri.path().value_or(""s), uri.queryParamMap());
-    }
-
-    std::string serialized() const {
-        return URI<RELAXED>::factory().path(std::string(_path)).setQuery(_params).build().str();
-    }
-
-    [[nodiscard]] std::size_t hash() const noexcept {
-        std::size_t seed = 0;
-        opencmw::detail::hash_combine(seed, _service);
-        opencmw::detail::hash_combine(seed, _path);
-        for (const auto &paramPair : _params) {
-            opencmw::detail::hash_combine(seed, paramPair.first);
-            opencmw::detail::hash_combine(seed, paramPair.second);
-        }
-
-        return seed;
-    }
-
-    std::string_view path() const { return _path; }
-    std::string_view service() const { return _service; }
-    const auto      &params() const { return _params; }
-};
-
-} // namespace opencmw::majordomo
-
-template<>
-struct fmt::formatter<opencmw::majordomo::SubscriptionData> {
-    template<typename ParseContext>
-    constexpr auto parse(ParseContext &ctx) {
-        return ctx.begin();
-    }
-
-    template<typename FormatContext>
-    auto format(const opencmw::majordomo::SubscriptionData &v, FormatContext &ctx) const {
-        return fmt::format_to(ctx.out(), "[service:{}, path:{}, params:{}]", v.service(), v.path(), v.params());
-    }
-};
-
-namespace std {
-template<>
-struct hash<opencmw::majordomo::SubscriptionData> {
-    std::size_t operator()(const opencmw::majordomo::SubscriptionData &k) const {
-        return k.hash();
-    }
-};
-
-} // namespace std
 
 namespace opencmw::majordomo {
 
@@ -156,14 +22,14 @@ public:
         _filters.emplace(key, std::make_unique<Filter>());
     }
 
-    bool operator()(const SubscriptionData &notified, const SubscriptionData &subscriber) const noexcept {
+    bool operator()(const mdp::SubscriptionTopic &notified, const mdp::SubscriptionTopic &subscriber) const noexcept {
         return testPathOnly(notified.service(), subscriber.service())
             && testPathOnly(notified.path(), subscriber.path())
             && testQueries(notified, subscriber);
     }
 
 private:
-    bool testQueries(const SubscriptionData &notified, const SubscriptionData &subscriber) const noexcept {
+    bool testQueries(const mdp::SubscriptionTopic &notified, const mdp::SubscriptionTopic &subscriber) const noexcept {
         const auto subscriberQuery = subscriber.params();
         if (subscriberQuery.empty()) {
             return true;

--- a/src/majordomo/include/majordomo/Worker.hpp
+++ b/src/majordomo/include/majordomo/Worker.hpp
@@ -255,9 +255,9 @@ private:
             return true;
         }
 
-        const auto topicString = data.substr(1);
-        // const auto topic       = URI<RELAXED>(std::string(topicString));
-        const SubscriptionData subscription(serviceName.data(), topicString, {});
+        const auto topicString  = data.substr(1);
+        const auto topicUrl     = URI<RELAXED>(std::string(topicString));
+        const auto subscription = SubscriptionData::fromURIAndServiceName(topicUrl, serviceName.data());
 
         // this assumes that the broker does the subscribe/unsubscribe counting
         // for multiple clients and sends us a single sub/unsub for each topic
@@ -274,9 +274,9 @@ private:
 
     bool receiveNotificationMessage() {
         if (auto message = zmq::receive<mdp::MessageFormat::WithoutSourceId>(_notifyListenerSocket)) {
-            // const auto topic                    = URI<RELAXED>(std::string(message->topic()));
-            const SubscriptionData currentSubscription(message->serviceName, message->endpoint.str(), {});
-            const auto             matchesNotificationTopic = [this, &currentSubscription](const auto &activeSubscription) {
+            const auto currentSubscription = SubscriptionData::fromURIAndServiceName(message->endpoint, message->serviceName);
+
+            const auto matchesNotificationTopic = [this, &currentSubscription](const auto &activeSubscription) {
                 return _subscriptionMatcher(currentSubscription, activeSubscription);
             };
 

--- a/src/majordomo/test/majordomo_tests.cpp
+++ b/src/majordomo/test/majordomo_tests.cpp
@@ -565,8 +565,8 @@ TEST_CASE("Pubsub example using SUB client/DEALER worker", "[broker][pubsub_sub_
     REQUIRE(broker.bind(publisherAddress, BindOption::Pub));
 
     BrokerMessageNode subscriber(broker.context, ZMQ_SUB);
-    REQUIRE(subscriber.connect(publisherAddress, "/a.topic"));
-    REQUIRE(subscriber.subscribe("/other.*"));
+    REQUIRE(subscriber.connect(publisherAddress, mdp::SubscriptionTopic("/a.topic")));
+    REQUIRE(subscriber.subscribe(mdp::SubscriptionTopic("/other.*")));
 
     broker.processMessages();
 
@@ -949,11 +949,11 @@ TEST_CASE("pubsub example using PUB socket (SUB client)", "[broker][pubsub_subcl
     MessageNode publisherTwo(broker.context);
     REQUIRE(publisherTwo.connect(opencmw::majordomo::INTERNAL_ADDRESS_BROKER));
 
-    subscriber.subscribe("/cooking.italian*");
+    subscriber.subscribe(mdp::SubscriptionTopic("/cooking.italian*"));
 
     broker.processMessages();
 
-    subscriber.subscribe("/cooking.indian*");
+    subscriber.subscribe(mdp::SubscriptionTopic("/cooking.indian*"));
 
     broker.processMessages();
 
@@ -1011,7 +1011,7 @@ TEST_CASE("pubsub example using PUB socket (SUB client)", "[broker][pubsub_subcl
         REQUIRE(reply->rbac.asString() == "rbac_worker_2");
     }
 
-    subscriber.unsubscribe("/cooking.italian*");
+    subscriber.unsubscribe(mdp::SubscriptionTopic("/cooking.italian*"));
 
     broker.processMessages();
 
@@ -1072,7 +1072,7 @@ TEST_CASE("BasicWorker run loop quits when broker quits", "[worker]") {
     auto                     quitBroker = std::jthread([&broker]() {
         std::this_thread::sleep_for(std::chrono::milliseconds(250));
         broker.shutdown();
-                        });
+    });
 
     worker.run(); // returns when broker disappears
     quitBroker.join();

--- a/src/majordomo/test/majordomoworker_tests.cpp
+++ b/src/majordomo/test/majordomoworker_tests.cpp
@@ -21,6 +21,7 @@ using opencmw::majordomo::Broker;
 using opencmw::majordomo::BrokerMessage;
 using opencmw::majordomo::Settings;
 using opencmw::majordomo::Worker;
+using opencmw::mdp::SubscriptionTopic;
 
 /*
  * This test serves as example on how MajordomoWorker is to be used.
@@ -184,8 +185,7 @@ TEST_CASE("MajordomoWorker test using raw messages", "[majordomo][majordomoworke
     BrokerMessageNode subClient(broker.context, ZMQ_SUB);
     REQUIRE(client.connect(opencmw::majordomo::INTERNAL_ADDRESS_BROKER));
     REQUIRE(subClient.connect(opencmw::majordomo::INTERNAL_ADDRESS_PUBLISHER));
-    constexpr auto testSubscription = std::string_view("/newAddress?ctx=FAIR.SELECTOR.C%3D1");
-    REQUIRE(subClient.subscribe(testSubscription));
+    REQUIRE(subClient.subscribe(mdp::SubscriptionTopic("/newAddress?ctx=FAIR.SELECTOR.C%3D1")));
 
     {
         auto request            = createClientMessage(mdp::Command::Get);
@@ -313,7 +313,7 @@ TEST_CASE("MajordomoWorker test using raw messages", "[majordomo][majordomoworke
         REQUIRE(worker.activeSubscriptions().size() == 1);
         REQUIRE(worker.activeSubscriptions().begin()->service() == "addressbook");
         REQUIRE(worker.activeSubscriptions().begin()->path() == "/newAddress");
-        REQUIRE(worker.activeSubscriptions().begin()->params() == SubscriptionData::map{{"ctx", "FAIR.SELECTOR.C=1"}});
+        REQUIRE(worker.activeSubscriptions().begin()->params() == SubscriptionTopic::map{ { "ctx", "FAIR.SELECTOR.C=1" } });
     }
 
     {

--- a/src/majordomo/test/majordomoworker_tests.cpp
+++ b/src/majordomo/test/majordomoworker_tests.cpp
@@ -184,7 +184,7 @@ TEST_CASE("MajordomoWorker test using raw messages", "[majordomo][majordomoworke
     BrokerMessageNode subClient(broker.context, ZMQ_SUB);
     REQUIRE(client.connect(opencmw::majordomo::INTERNAL_ADDRESS_BROKER));
     REQUIRE(subClient.connect(opencmw::majordomo::INTERNAL_ADDRESS_PUBLISHER));
-    const char *testSubscription = "/newAddress?ctx=FAIR.SELECTOR.C%3D1";
+    constexpr auto testSubscription = std::string_view("/newAddress?ctx=FAIR.SELECTOR.C%3D1");
     REQUIRE(subClient.subscribe(testSubscription));
 
     {
@@ -311,7 +311,9 @@ TEST_CASE("MajordomoWorker test using raw messages", "[majordomo][majordomoworke
         };
         REQUIRE(worker.notify("/newAddress", TestContext{ .ctx = opencmw::TimingCtx(1), .contentType = opencmw::MIME::JSON }, entry));
         REQUIRE(worker.activeSubscriptions().size() == 1);
-        REQUIRE(std::string_view(testSubscription).starts_with(worker.activeSubscriptions().begin()->serialized()));
+        REQUIRE(worker.activeSubscriptions().begin()->service() == "addressbook");
+        REQUIRE(worker.activeSubscriptions().begin()->path() == "/newAddress");
+        REQUIRE(worker.activeSubscriptions().begin()->params() == SubscriptionData::map{{"ctx", "FAIR.SELECTOR.C=1"}});
     }
 
     {

--- a/src/majordomo/test/subscriptionmatcher_tests.cpp
+++ b/src/majordomo/test/subscriptionmatcher_tests.cpp
@@ -9,12 +9,12 @@
 
 #include <charconv>
 
-using opencmw::majordomo::SubscriptionData;
 using opencmw::majordomo::SubscriptionMatcher;
+using opencmw::mdp::SubscriptionTopic;
 
 struct SubscriptionUriMatcher : SubscriptionMatcher {
     bool operator()(const auto &notified, const auto &subscriber) const {
-        return SubscriptionMatcher::operator()(SubscriptionData::fromURI(notified), SubscriptionData::fromURI(subscriber));
+        return SubscriptionMatcher::operator()(SubscriptionTopic::fromURI(notified), SubscriptionTopic::fromURI(subscriber));
     }
 };
 


### PR DESCRIPTION
 - Ensure that a client subscription "/service?a=b" arrives in the worker as such, and not as "/service".
 - Ensure that clients subscriptions "/service?a&b" and "/service?b&a" are treated the same, i.e. that the params are sorted alphabetically when passed to ZMQ.
