### PR TITLE
Https subscription and root certs

### DIFF
--- a/src/client/include/RestDefaultClientCertificates.hpp
+++ b/src/client/include/RestDefaultClientCertificates.hpp
@@ -18,6 +18,15 @@ public:
         _concatenated_certificates += root_certificates[1];
         _concatenated_certificates += root_certificates[2];
         _concatenated_certificates += root_certificates[3];
+
+        if (auto filename = std::getenv("OPENCMW_REST_CERT_FILE"); filename) {
+            std::ifstream ifs{ filename };
+            if (!ifs.is_open()) {
+                std::string cert;
+                ifs >> cert;
+                _concatenated_certificates += cert;
+            }
+        }
     }
     constexpr std::string get() const noexcept {
         return _concatenated_certificates;


### PR DESCRIPTION
Implement https subscriptions and fix a bug related to our handling regarding the https client.

Https subscriptions were just not handled, initialise a client and reuse the existing code for http subscriptions.
There was a bug in our certificate store handling. The SSLClient owns its certificate store and deletes it on destruction.
We can not share one store with all clients, so every client gets its own now.