### PR TITLE
Disruptor: Correctly rethrow exception

### DIFF
--- a/src/disruptor/include/disruptor/RingBuffer.hpp
+++ b/src/disruptor/include/disruptor/RingBuffer.hpp
@@ -214,7 +214,7 @@ public:
                 } while (processNextEvent && nextSequence <= availableSequence);
             } catch (...) {
                 _sequence->setValue(processedSequence);
-                throw std::current_exception();
+                std::rethrow_exception(std::current_exception());
             }
 
             _sequence->setValue(processedSequence);


### PR DESCRIPTION
Don't rethrow the exception_ptr, but the contained exception.