### PR TITLE
Upgrade to cpp-httplib v0.18.1

### DIFF
--- a/cmake/DependenciesNative.cmake
+++ b/cmake/DependenciesNative.cmake
@@ -18,7 +18,7 @@ option(WITH_PERF_TOOL "Build with perf-tools" OFF)
 FetchContent_Declare(
         cpp-httplib
         GIT_REPOSITORY https://github.com/yhirose/cpp-httplib.git
-        GIT_TAG v0.14.2 # latest v0.14.2
+        GIT_TAG v0.18.1 # latest v0.18.1
 )
 
 # zlib: optional httplib dependency


### PR DESCRIPTION
Enabling TESTING on opendigitizer fails
to build as due httplib used here not
having the required status enums.