### PR TITLE
Clang: Enable libc++ and require clang-18, bump zmq to latest release

### DIFF
--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -64,6 +64,7 @@ jobs:
         sudo apt update
         sudo apt upgrade -y
         sudo apt install -y clang-18 libc++-18-dev libc++abi-18-dev
+        sudo update-alternatives --install /usr/bin/cc cc /usr/bin/clang-18 110
         sudo update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++-18 110
 
     - name: Install emscripten
@@ -85,7 +86,7 @@ jobs:
       if: matrix.configurations.compiler != 'emscripten'
       # Use a bash shell, so we can use the same syntax for environment variable access regardless of the host operating system
       shell: bash
-      run: cmake -S . -B ../build -DCMAKE_BUILD_TYPE=${{ matrix.cmake-build-type }} -DOPENCMW_ENABLE_COVERAGE=${{ matrix.configurations.name == env.REFERENCE_CONFIG && matrix.cmake-build-type == 'Debug' }}
+      run: cmake -S . -B ../build -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DCMAKE_BUILD_TYPE=${{ matrix.cmake-build-type }} -DOPENCMW_ENABLE_COVERAGE=${{ matrix.configurations.name == env.REFERENCE_CONFIG && matrix.cmake-build-type == 'Debug' }}
 
     - name: Configure CMake Emscripten
       if: matrix.configurations.compiler == 'emscripten'
@@ -94,7 +95,7 @@ jobs:
       run: |
         export SYSTEM_NODE=`which node` # use system node instead of old version distributed with emsdk for threading support
         source ~/emsdk/emsdk_env.sh
-        emcmake cmake -S . -B ../build -DCMAKE_BUILD_TYPE=${{ matrix.cmake-build-type }} -DENABLE_TESTING=ON -DCMAKE_CROSSCOMPILING_EMULATOR=${SYSTEM_NODE}
+        emcmake cmake -S . -B ../build -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DCMAKE_BUILD_TYPE=${{ matrix.cmake-build-type }} -DENABLE_TESTING=ON -DCMAKE_CROSSCOMPILING_EMULATOR=${SYSTEM_NODE}
 
     - name: Build
       if: matrix.configurations.name != env.REFERENCE_CONFIG || matrix.cmake-build-type != 'Debug'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.19)
+cmake_minimum_required(VERSION 3.5)
 
 project(opencmw-cpp CXX C) # C is needed to compile the internal version of libsodium
 set(CMAKE_CXX_STANDARD 23)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,8 +55,12 @@ elseif(EMSCRIPTEN)
     "SHELL:-s PTHREAD_POOL_SIZE=30"
     "SHELL:-s FETCH=1")
 elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 15.0.0)
-    message(FATAL_ERROR "Clang>=15.0.0 required, but clang ${CMAKE_CXX_COMPILER_VERSION} detected.")
+  # set default C++ STL to Clang's libc++ when using Clang
+  add_compile_options(-stdlib=libc++)
+  add_compile_options(-fexperimental-library) # needed for std::jthread with clang-18
+  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -stdlib=libc++ -lc++")
+  if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 18.0.0)
+    message(FATAL_ERROR "Clang>=18.0.0 required, but clang ${CMAKE_CXX_COMPILER_VERSION} detected.")
   endif()
 else()
   message(

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -25,7 +25,7 @@ FetchContent_Declare(
 FetchContent_Declare(
         gsl-lite
         GIT_REPOSITORY https://github.com/gsl-lite/gsl-lite.git
-        GIT_TAG v0.40.0
+        GIT_TAG v0.42.0 # latest as of 2025-04-02
 )
 
 set(FMT_INSTALL True)

--- a/cmake/DependenciesNative.cmake
+++ b/cmake/DependenciesNative.cmake
@@ -35,7 +35,7 @@ add_library(mustache::mustache ALIAS mustache)
 FetchContent_Declare(
         zeromq
         GIT_REPOSITORY https://github.com/zeromq/libzmq.git
-        GIT_TAG v4.3.4 # latest v4.3.4
+        GIT_TAG v4.3.5 # latest as of 2025-03-27
 )
 set(ZMQ_BUILD_TESTS OFF CACHE BOOL "Build the tests for ZeroMQ")
 # suppress warnings for missing zeromq dependencies by disabling some features

--- a/concepts/client/dns_example.cpp
+++ b/concepts/client/dns_example.cpp
@@ -58,7 +58,8 @@ void register_device(auto &client, std::string_view signal) {
 }
 
 void query_devices(auto &client, std::string_view query) {
-    Entry query_filter{ .signal_name = std::string{ query } };
+    Entry query_filter;
+    query_filter.signal_name = std::string{ query };
     auto  signals = client.querySignals(query_filter);
     std::cout << "found signal: " << signals << std::endl;
 }

--- a/src/client/include/MockServer.hpp
+++ b/src/client/include/MockServer.hpp
@@ -47,7 +47,6 @@ public:
     bool processRequest(Callback handler) {
         const auto result           = zmq::invoke(zmq_poll, _pollerItems.data(), static_cast<int>(_pollerItems.size()), _settings.heartbeatInterval.count());
         bool       anythingReceived = false;
-        int        loopCount        = 0;
         do {
             auto maybeMessage = zmq::receive<mdp::MessageFormat::WithoutSourceId>(_socket.value());
             if (!maybeMessage) { // empty message
@@ -62,8 +61,6 @@ public:
             auto reply = replyFromRequest(message);
             handler(message, reply);
             zmq::send(std::move(reply), _socket.value()).assertSuccess();
-
-            loopCount++;
         } while (anythingReceived);
         // N.B. block until data arrived or for at most one heart-beat interval
         return result.isValid();

--- a/src/client/include/RestClientNative.hpp
+++ b/src/client/include/RestClientNative.hpp
@@ -331,8 +331,6 @@ private:
                             std::string updateIdxString = URI<STRICT>(location).queryParamMap().at(std::string(LONG_POLLING_IDX_TAG)).value_or("0");
                             char       *end             = updateIdxString.data() + updateIdxString.size();
                             longPollingIdx              = strtoull(updateIdxString.data(), &end, 10) + 1;
-                            auto headerTimestamp        = result->get_header_value_u64("X-TIMESTAMP");
-                            auto latency                = headerTimestamp - std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::high_resolution_clock::now().time_since_epoch()).count();
                         } else { // failed or server is down -> wait until retry
                             if (_run) {
                                 returnMdpMessage(cmd, result, fmt::format("Long-Polling-GET request failed for {}: {}", cmd.topic.str(), static_cast<int>(result.error())));

--- a/src/client/test/RestClient_tests.cpp
+++ b/src/client/test/RestClient_tests.cpp
@@ -157,7 +157,7 @@ TEST_CASE("Multiple Rest Client Get/Set Test - HTTPS", "[Client]") {
     dones[1] = false;
     dones[2] = false;
     dones[3] = false;
-    std::atomic<int> counter{ 0 };
+    std::atomic<std::size_t> counter{ 0 };
     auto             makeCommand = [&]() {
         IoBuffer data;
         data.put('A');
@@ -169,8 +169,8 @@ TEST_CASE("Multiple Rest Client Get/Set Test - HTTPS", "[Client]") {
         command.command  = mdp::Command::Get;
         command.topic    = URI<STRICT>("https://localhost:8080/endPoint");
         command.data     = std::move(data);
-        command.callback = [&dones, &counter](const mdp::Message             &/*rep*/) {
-            int currentCounter = counter.fetch_add(1, std::memory_order_relaxed);
+        command.callback = [&dones, &counter](const mdp::Message         &/*rep*/) {
+            std::size_t currentCounter = counter.fetch_add(1, std::memory_order_relaxed);
             dones[currentCounter].store(true, std::memory_order_release);
             // Assuming you have access to 'done' variable, uncomment the following line
             dones[currentCounter].notify_all();

--- a/src/core/include/Filters.hpp
+++ b/src/core/include/Filters.hpp
@@ -45,13 +45,11 @@ class NumberFilter : public AbstractFilter {
 public:
     bool operator()(std::string_view notified, std::string_view subscribed) const override {
         T          subscribedNumber = {};
-        const auto r1               = std::from_chars(subscribed.begin(), subscribed.end(), subscribedNumber);
-        if (r1.ec == std::errc::invalid_argument) {
+        if (const auto rc = parseNumber(subscribed, subscribedNumber); rc == std::errc::invalid_argument) {
             return false;
         }
         T          notifiedNumber = {};
-        const auto r2             = std::from_chars(notified.begin(), notified.end(), notifiedNumber);
-        if (r2.ec == std::errc::invalid_argument) {
+        if (const auto rc = parseNumber(notified, notifiedNumber); rc == std::errc::invalid_argument) {
             return false;
         }
 

--- a/src/core/include/ThreadPool.hpp
+++ b/src/core/include/ThreadPool.hpp
@@ -347,7 +347,7 @@ public:
         if constexpr (cpuID >= 0) {
             if (cpuID >= _affinityMask.size() || !_affinityMask[cpuID]) {
                 throw std::invalid_argument(fmt::format("cpuID {} is out of range [0,{}] or incompatible with set affinity mask [{}]",
-                        cpuID, _affinityMask.size(), _affinityMask));
+                        cpuID, _affinityMask.size(), fmt::join(_affinityMask, ",")));
             }
         }
         std::promise<R> promise;

--- a/src/core/include/TimingCtx.hpp
+++ b/src/core/include/TimingCtx.hpp
@@ -11,12 +11,9 @@
 #include <string_view>
 
 #include <fmt/format.h>
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wuseless-cast" // suppress warning caused by gsl-lite: https://github.com/gsl-lite/gsl-lite/issues/325
 #include <units/chrono.h>
 #include <units/isq/dimensions/time.h>
 #include <units/isq/si/time.h>
-#pragma GCC diagnostic pop
 
 namespace opencmw {
 

--- a/src/core/include/opencmw.hpp
+++ b/src/core/include/opencmw.hpp
@@ -2,6 +2,8 @@
 #define OPENCMW_H
 
 #include <array>
+#include <cerrno>
+#include <charconv>
 #include <chrono>
 #include <concepts>
 #include <map>
@@ -749,6 +751,51 @@ inline constexpr void diffView(std::ostream &os, const T &lhs, const T &rhs) {
     if (indent == 0) {
         os << std::endl;
     }
+}
+
+template<typename T>
+static std::errc parseNumber(std::string_view str, T &number) {
+    // wrapper for missing std::from_chars() support for floating point types in clang < 20
+    // Note that this implementation is intolerant to trailing non-number junk in the given string.
+#ifdef __clang__
+    if constexpr (std::is_same_v<T, float>) {
+        char *endPtr = nullptr;
+        float value  = std::strtof(str.data(), &endPtr);
+        if (endPtr == str.data() + str.size() && errno == 0) {
+            number = value;
+            return std::errc{};
+        }
+        return std::errc::invalid_argument;
+    } else if constexpr (std::is_same_v<T, double>) {
+        char  *endPtr = nullptr;
+        double value  = std::strtod(str.data(), &endPtr);
+        if (endPtr == str.data() + str.size() && errno == 0) {
+            number = value;
+            return std::errc{};
+        }
+        return std::errc::invalid_argument;
+    } else if constexpr (std::is_same_v<T, long double>) {
+        char       *endPtr = nullptr;
+        long double value  = std::strtold(str.data(), &endPtr);
+        if (endPtr == str.data() + str.size() && errno == 0) {
+            number = value;
+            return std::errc{};
+        }
+        return std::errc::invalid_argument;
+    } else {
+        const auto rc = std::from_chars(str.data(), str.data() + str.size(), number);
+        if (rc.ptr == str.data() + str.size() && rc.ec == std::errc{}) {
+            return std::errc{};
+        }
+        return rc.ec == std::errc{} ? std::errc::invalid_argument : rc.ec;
+    }
+#else
+    const auto rc = std::from_chars(str.data(), str.data() + str.size(), number);
+    if (rc.ptr == str.data() + str.size() && rc.ec == std::errc{}) {
+        return std::errc{};
+    }
+    return rc.ec == std::errc{} ? std::errc::invalid_argument : rc.ec;
+#endif
 }
 
 } // namespace opencmw

--- a/src/core/include/opencmw.hpp
+++ b/src/core/include/opencmw.hpp
@@ -15,12 +15,10 @@
 #include <fmt/ostream.h>
 #include <fmt/ranges.h>
 #include <refl.hpp>
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wuseless-cast" // suppress warning caused by gsl-lite: https://github.com/gsl-lite/gsl-lite/issues/325
+
 #include <units/concepts.h>
 #include <units/quantity.h>
 #include <units/quantity_io.h>
-#pragma GCC diagnostic pop
 
 #define FWD(x) std::forward<decltype(x)>(x)               // short-hand notation
 #define forceinline inline __attribute__((always_inline)) // use this for hot-spots only <-> may bloat code size, not fit into cache and consequently slow down execution

--- a/src/core/test/MIME_tests.cpp
+++ b/src/core/test/MIME_tests.cpp
@@ -45,7 +45,7 @@ TEST_CASE("basic access", "[MIME]") {
     REQUIRE(MIME::getTypeByFileName("FileName.unknown") == MIME::UNKNOWN);
 
     const char *_typeN = MIME::TEXT;
-    REQUIRE(_typeN == "text/plain");
+    REQUIRE(_typeN == std::string_view("text/plain"));
 
     std::vector<opencmw::MIME::MimeType> v{ MIME::TEXT, MIME::JAR };
     std::cout << v;

--- a/src/disruptor/test/Setting_tests.cpp
+++ b/src/disruptor/test/Setting_tests.cpp
@@ -91,7 +91,12 @@ TEST_CASE("SettingBase basic tests", "[SettingBase]") {
     REQUIRE(!r3);
     REQUIRE(a.getPendingTransactions().size() == 1);
     REQUIRE(a.nHistory() == 3);
-    auto [r4, t4] = a.commit(40);
+#ifdef __clang__ // workaround to ensure t3 != t4 (system_clock::now() must return different values) (issue #368)
+    std::this_thread::sleep_for(std::chrono::milliseconds(5));
+#endif
+    auto [r4, t4]
+            = a.commit(40);
+    REQUIRE(t3 != t4);
     REQUIRE(r4);
     REQUIRE(a.nHistory() == 4);
     REQUIRE(a.get(t4) == 40);

--- a/src/majordomo/include/majordomo/Broker.hpp
+++ b/src/majordomo/include/majordomo/Broker.hpp
@@ -734,8 +734,9 @@ private:
             auto workerIt = service.waiting.begin();
             while (workerIt != service.waiting.end()) {
                 if ((*workerIt)->expiry < now) {
+                    auto id  = (*workerIt)->id;
                     workerIt = service.waiting.erase(workerIt);
-                    _workers.erase((*workerIt)->id);
+                    _workers.erase(id);
                 } else {
                     ++workerIt;
                 }

--- a/src/majordomo/include/majordomo/Rbac.hpp
+++ b/src/majordomo/include/majordomo/Rbac.hpp
@@ -24,7 +24,7 @@ public:
     [[nodiscard]] static constexpr std::string_view name() { return roleName.data_; }
     [[nodiscard]] static constexpr Permission       rights() { return accessRights; }
     template<typename ROLE>
-    [[nodiscard]] constexpr bool operator==(const ROLE &other) const noexcept {
+    [[nodiscard]] constexpr bool operator==(const ROLE &) const noexcept {
         return std::is_same_v<ROLE, Role<roleName, accessRights>>;
     }
 };

--- a/src/majordomo/include/majordomo/RestBackend.hpp
+++ b/src/majordomo/include/majordomo/RestBackend.hpp
@@ -7,6 +7,7 @@
 #include <iostream>
 #include <optional>
 #include <regex>
+#include <shared_mutex>
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wformat-nonliteral"
@@ -15,6 +16,7 @@
 #pragma GCC diagnostic ignored "-Wshadow"
 #pragma GCC diagnostic ignored "-Wuninitialized"
 #pragma GCC diagnostic ignored "-Wuseless-cast"
+#undef CPPHTTPLIB_THREAD_POOL_COUNT
 #define CPPHTTPLIB_THREAD_POOL_COUNT 8
 #include <httplib.h>
 #pragma GCC diagnostic pop
@@ -533,7 +535,7 @@ public:
             return worker.respondWithSubscription(response, topic);
         default:
             // std::unreachable() is C++23
-            assert(!"We have already checked that restMethod is not Invalid");
+            assert(false && "We have already checked that restMethod is not Invalid");
             return false;
         }
     }

--- a/src/majordomo/include/majordomo/Worker.hpp
+++ b/src/majordomo/include/majordomo/Worker.hpp
@@ -325,11 +325,11 @@ private:
                 }
                 return;
             default:
-                assert(!"not implemented");
+                assert(false && "not implemented");
                 return;
             }
         } else {
-            assert(!"not implemented");
+            assert(false && "not implemented");
         }
     }
 

--- a/src/majordomo/test/majordomo_tests.cpp
+++ b/src/majordomo/test/majordomo_tests.cpp
@@ -8,6 +8,7 @@
 
 #include <charconv>
 #include <cstdlib>
+#include <optional>
 #include <thread>
 
 // Concepts and tests use common types
@@ -370,6 +371,24 @@ TEST_CASE("Test Topic class", "[mdp][topic]") {
         REQUIRE(t1.toZmqTopic() == t3.toZmqTopic());
         REQUIRE(t1.toMdpTopic().path().value_or("") == "/a/service");
         REQUIRE(t1.toMdpTopic().queryParamMap().empty());
+    }
+
+    SECTION("hash function") {
+        const auto t1 = Topic::fromString("/a/service?p1=foo", {});
+        const auto t2 = Topic::fromString("/a/service", { { "p1", "foo" } });
+        REQUIRE(t1 == t2);
+        REQUIRE(t1.hash() == t2.hash());
+        const auto t3 = Topic::fromString("/a/service?p1=foo&p2=bar", {});
+        const auto t4 = Topic::fromString("/a/service?p2=bar&p1=foo", {});
+        const auto t5 = Topic::fromString("/a/service", { { "p1", "foo" }, { "p2", "bar" } });
+        REQUIRE(t3 == t4);
+        REQUIRE(t4 == t5);
+        REQUIRE(t3.hash() == t4.hash());
+        REQUIRE(t4.hash() == t5.hash());
+        const auto t6 = Topic::fromString("/a/service?p1=", {});
+        const auto t7 = Topic::fromString("/a/service", { { "p1", std::nullopt } });
+        REQUIRE(t6 == t7);
+        REQUIRE(t6.hash() == t7.hash());
     }
 }
 

--- a/src/serialiser/include/QuerySerialiser.hpp
+++ b/src/serialiser/include/QuerySerialiser.hpp
@@ -85,8 +85,7 @@ struct QuerySerialiser<T> {
             throw std::invalid_argument("Empty string is not a valid number");
         }
 
-        const auto r = std::from_chars(maybeStr->data(), maybeStr->data() + maybeStr->size(), v);
-        if (r.ec == std::errc::invalid_argument) {
+        if (const auto rc = parseNumber(maybeStr.value(), v); rc == std::errc::invalid_argument) {
             throw std::invalid_argument(fmt::format("Cannot parse as number '{}'", *maybeStr));
         }
     }
@@ -126,8 +125,8 @@ struct QuerySerialiser<opencmw::MIME::MimeType> {
     }
 };
 
-template<ReflectableClass C>
-C deserialise(const QueryMap &m) {
+template<ReflectableClass C, MapLike TMap>
+C deserialise(const TMap &m) {
     C context;
 
     for_each(refl::reflect(context).members, [&](const auto member, [[maybe_unused]] const auto index) {

--- a/src/serialiser/test/IoSerialiserJson_tests.cpp
+++ b/src/serialiser/test/IoSerialiserJson_tests.cpp
@@ -6,11 +6,8 @@
 #include <iostream>
 #include <string_view>
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wuseless-cast" // suppress warning caused by gsl-lite: https://github.com/gsl-lite/gsl-lite/issues/325
 #include <units/isq/si/length.h>
 #include <units/isq/si/speed.h>
-#pragma GCC diagnostic pop
 
 #include <Debug.hpp>
 #include <IoSerialiserJson.hpp>

--- a/src/serialiser/test/IoSerialiserYAML_tests.cpp
+++ b/src/serialiser/test/IoSerialiserYAML_tests.cpp
@@ -3,14 +3,11 @@
 #include <iostream>
 #include <string_view>
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wuseless-cast" // suppress warning caused by gsl-lite: https://github.com/gsl-lite/gsl-lite/issues/325
 #include <units/isq/si/energy.h>
 #include <units/isq/si/length.h>
 #include <units/isq/si/mass.h>
 #include <units/isq/si/resistance.h>
 #include <units/isq/si/time.h>
-#pragma GCC diagnostic pop
 
 #include <Debug.hpp>
 #include <IoSerialiserYAML.hpp>

--- a/src/serialiser/test/IoSerialiserYaS_tests.cpp
+++ b/src/serialiser/test/IoSerialiserYaS_tests.cpp
@@ -8,8 +8,6 @@
 #include <opencmw.hpp>
 #include <string_view>
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wuseless-cast" // suppress warning caused by gsl-lite: https://github.com/gsl-lite/gsl-lite/issues/325
 #include <units/isq/si/electric_current.h>
 #include <units/isq/si/energy.h>
 #include <units/isq/si/length.h>
@@ -17,7 +15,6 @@
 #include <units/isq/si/resistance.h>
 #include <units/isq/si/speed.h>
 #include <units/isq/si/time.h>
-#pragma GCC diagnostic pop
 
 #include <Debug.hpp>
 #include <IoSerialiserYaS.hpp>

--- a/src/serialiser/test/Utils_tests.cpp
+++ b/src/serialiser/test/Utils_tests.cpp
@@ -7,8 +7,6 @@
 #include <iostream>
 #include <string_view>
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wuseless-cast" // suppress warning caused by gsl-lite: https://github.com/gsl-lite/gsl-lite/issues/325
 #include <units/isq/si/electric_current.h>
 #include <units/isq/si/energy.h>
 #include <units/isq/si/length.h>
@@ -16,7 +14,6 @@
 #include <units/isq/si/resistance.h>
 #include <units/isq/si/speed.h>
 #include <units/isq/si/time.h>
-#pragma GCC diagnostic pop
 
 #include <Debug.hpp>
 #include <IoSerialiser.hpp>

--- a/src/services/test/dns_tests.cpp
+++ b/src/services/test/dns_tests.cpp
@@ -390,7 +390,7 @@ TEST_CASE("registering", "[DNS]") {
         entries[2].ttl = std::chrono::system_clock::now();
         auto ttl       = entries[2].ttl;
         auto reEntry   = entries[2];
-#ifdef __EMSCRIPTEN__
+#if (defined __EMSCRIPTEN__) || defined(__clang__)
         std::this_thread::sleep_for(0.5s); // seems that the clock resultion results in fReEntry->ttl == ttl
 #endif
         ds.addEntry(reEntry);


### PR DESCRIPTION
Ensure libc++ is used when using clang, in preparation for using e.g. std::expected. Bump minimum version to clang 18.
    
Make sure mdp::Topic::hash() is equal for equal instances, the implementation of hash() iterating the params in an undefined order assumed hash_combine/std::hash to be commutative, which doesn't seem to be the case when using libc++'s std::hash.