### PR TITLE
Fix `received unexpected update` warning.

### DIFF
--- a/src/client/include/RestClientEmscripten.hpp
+++ b/src/client/include/RestClientEmscripten.hpp
@@ -206,10 +206,11 @@ struct SubscriptionPayload : FetchPayload {
                     return;
                 }
 
-                if (payload->_update != 0 && longPollingIdx != payload->_update) {
-                    std::print("received unexpected update: {}, expected {}\n", longPollingIdx, payload->_update);
+                const long indexDiff = static_cast<long>(longPollingIdx) - static_cast<long>(payload->_update + 1);
+                if (payload->_update != 0 && indexDiff != 0) {
+                    std::print("received unexpected update: {}, expected {}\n", longPollingIdx, payload->_update + 1);
                 }
-                payload->onsuccess(fetch->status, std::string_view(fetch->data, detail::checkedStringViewSize(fetch->numBytes)), static_cast<long>(longPollingIdx) - static_cast<long>(payload->_update));
+                payload->onsuccess(fetch->status, std::string_view(fetch->data, detail::checkedStringViewSize(fetch->numBytes)), indexDiff);
                 emscripten_fetch_close(fetch);
 
                 payload->_update = longPollingIdx;
@@ -244,7 +245,7 @@ struct SubscriptionPayload : FetchPayload {
 class RestClient : public ClientBase {
     std::string       _name;
     MIME::MimeType    _mimeType = MIME::BINARY;
-    std::atomic<bool> _run = true;
+    std::atomic<bool> _run      = true;
     std::string       _caCertificate;
 
 public:


### PR DESCRIPTION
The reason was that the new longPollingIdx was compared against the last value already processed (playload->_update). The correct comparison must be with playload->_update + 1.

for more info see comment: https://github.com/fair-acc/opencmw-cpp/pull/371#discussion_r2158449274