### PR TITLE
RestClient: only single long poll request

### DIFF
--- a/src/client/include/RestClientEmscripten.hpp
+++ b/src/client/include/RestClientEmscripten.hpp
@@ -140,7 +140,7 @@ struct SubscriptionPayload : FetchPayload {
     MIME::MimeType               _mimeType;
     std::size_t                  _update                      = 0;
 
-    static constexpr std::size_t kParallelLongPollingRequests = 3;
+    static constexpr std::size_t kParallelLongPollingRequests = 1; // increasing this value could reduce latency but needs some more robust error handling for unexpected updates
     std::vector<std::uint64_t>   _requestedIndexes;
 
     SubscriptionPayload(Command &&_command, MIME::MimeType mimeType)

--- a/src/client/include/RestClientNative.hpp
+++ b/src/client/include/RestClientNative.hpp
@@ -107,7 +107,7 @@ struct RequestResponse {
     }
 };
 
-constexpr std::size_t kParallelLongPollingRequests = 3;
+constexpr std::size_t kParallelLongPollingRequests = 1; // increasing this value could reduce latency but needs some more robust error handling for unexpected updates
 
 struct Subscription {
     client::Command                                   request;


### PR DESCRIPTION
PR #371 introduced that long polling subscriptions would always fetch the next n (defaulted to 3) long polling indices to reduce the latency from roundtrip to single trip.
For the happy path this works well, but in case of errors, the logic has to be improved to correctly handle responses arriving out of order. With the current logic this will re-fetch already received updates and lead to avalanches of requests, as these re-fetched requests will then also again arive out of order and refetch old data. Before increasing this value again, it should be ensured that the responses are either re-sorted on arrival or older updates correctly dropped without scheduling new requests.

This change restores the behaviour from before the changes but keeps the logic in place so it can be reenabled after fixing the error-handling.