### PR TITLE
meta: align .zenodo.json license with the Zenodo deposit schema; add concept DOI

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,9 +1,7 @@
 {
   "title": "OpenCMW C++",
   "description": "OpenCMW C++ — an open common middle-ware library for equipment access and data serialisation.",
-  "license": {
-    "id": "LGPL-3.0-only"
-  },
+  "license": "lgpl-3.0-only",
   "upload_type": "software",
   "creators": [
     {

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -4,6 +4,10 @@ message: "If you use this software, please cite it using the metadata from this 
 type: software
 license: LGPL-3.0-only
 repository-code: "https://github.com/fair-acc/opencmw-cpp"
+identifiers:
+  - type: doi
+    value: "10.5281/zenodo.19007383"
+    description: "Concept DOI resolving to the latest published version on Zenodo."
 keywords:
   - middle-ware
   - equipment access


### PR DESCRIPTION
## What

Two small citation-metadata hygiene fixes, mirroring the cleanup applied to `fair-acc/opendigitizer`:

- **`.zenodo.json`** — the `license` field used the InvenioRDM record object form (`{"id": "LGPL-3.0-only"}`). The GitHub→Zenodo deposit expects the [documented](https://help.zenodo.org/docs/github/describe-software/zenodo-json/) lowercase SPDX **string** (`"lgpl-3.0-only"`); the object form is ignored, leaving Zenodo to auto-detect the licence from `LICENSE`. This makes the deposit explicit and schema-correct — **no licence change** (still LGPL-3.0).
- **`CITATION.cff`** — added the Zenodo **concept DOI** [`10.5281/zenodo.19007383`](https://doi.org/10.5281/zenodo.19007383) as an identifier, so "cite this repository" resolves to the all-versions record.

Author roster, keywords and everything else are unchanged.
